### PR TITLE
[CTM-312]TDR: Exporting Snapshot Error 

### DIFF
--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -20,12 +20,10 @@ import bio.terra.service.filedata.exception.FileNotFoundException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotProject;
-import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
-import com.google.cloud.firestore.QuerySnapshot;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
@@ -384,7 +382,8 @@ public class FireStoreDao {
 
   /**
    * Process all documents in a collection using pagination to avoid query timeouts. Documents are
-   * processed in batches as they are fetched using cursor-based pagination.
+   * processed in batches as they are fetched using cursor-based pagination. Only the fileId and
+   * gspath fields are selected for efficiency.
    *
    * @param projectId The Google project ID
    * @param collectionName The name of the collection to process
@@ -400,33 +399,26 @@ public class FireStoreDao {
     final CollectionReference collection = db.collection(collectionName);
     int batchSize = configurationService.getParameterValue(ConfigEnum.FIRESTORE_QUERY_BATCH_SIZE);
 
-    int batchCount = 0;
-    List<QueryDocumentSnapshot> documents = new ArrayList<>();
-    do {
-      QueryDocumentSnapshot lastDocument =
-          documents.size() > 0 ? documents.get(documents.size() - 1) : null;
+    // Create query with select to only fetch fileId and gspath fields
+    Query query =
+        collection.select(FireStoreFile.FILE_ID_FIELD_NAME, FireStoreFile.GS_PATH_FIELD_NAME);
 
-      documents =
-          fireStoreUtils.runTransactionWithRetry(
-              db,
-              xn -> {
-                Query query = collection.limit(batchSize);
-                if (lastDocument != null) {
-                  query = query.startAfter(lastDocument);
-                }
-                ApiFuture<QuerySnapshot> querySnapshot = xn.get(query);
-                return querySnapshot.get().getDocuments();
-              },
-              "processCollectionWithPagination",
-              " scanning " + batchSize + " items for collection: " + collectionName);
+    // Use FireStoreBatchQueryIterator to handle pagination
+    FireStoreBatchQueryIterator queryIterator =
+        new FireStoreBatchQueryIterator(query, batchSize, fireStoreUtils, 0, Integer.MAX_VALUE);
+
+    int batchCount = 0;
+    for (List<QueryDocumentSnapshot> batch = queryIterator.getBatch();
+        batch != null;
+        batch = queryIterator.getBatch()) {
       batchCount++;
-      if (!documents.isEmpty()) {
+      if (!batch.isEmpty()) {
         logger.info("Visiting batch {} of ~{} documents", batchCount, batchSize);
-        for (QueryDocumentSnapshot document : documents) {
+        for (QueryDocumentSnapshot document : batch) {
           documentProcessor.accept(document);
         }
       }
-    } while (documents.size() > 0);
+    }
   }
 
   public FSItem retrieveBySnapshotAndId(SnapshotProject snapshot, String fileId, int enumerateDepth)

--- a/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
+++ b/src/main/java/bio/terra/service/filedata/google/firestore/FireStoreDao.java
@@ -20,8 +20,11 @@ import bio.terra.service.filedata.exception.FileNotFoundException;
 import bio.terra.service.filedata.exception.FileSystemExecutionException;
 import bio.terra.service.snapshot.Snapshot;
 import bio.terra.service.snapshot.SnapshotProject;
+import com.google.api.core.ApiFuture;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -29,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -381,25 +383,50 @@ public class FireStoreDao {
   }
 
   /**
-   * Given a snapshot, retrieve the -files metadata collection from its source Dataset Firestore
+   * Process all documents in a collection using pagination to avoid query timeouts. Documents are
+   * processed in batches as they are fetched using cursor-based pagination.
    *
-   * @param snapshot target snapshot
-   * @return QuerySnapshot representation of the -files collection in source Dataset.
+   * @param projectId The Google project ID
+   * @param collectionName The name of the collection to process
+   * @param documentProcessor A consumer that processes each document
+   * @throws InterruptedException If the operation is interrupted
    */
-  public QuerySnapshot retrieveFilesCollection(Snapshot snapshot)
-      throws ExecutionException, InterruptedException {
-    Dataset sourceDataset = snapshot.getSourceDataset();
-    String collectionName = String.format("%s-files", sourceDataset.getId());
-    return retrieveCollectionByName(
-        sourceDataset.getProjectResource().getGoogleProjectId(), collectionName);
-  }
-
-  public QuerySnapshot retrieveCollectionByName(String projectId, String collectionName)
-      throws ExecutionException, InterruptedException {
+  public void processCollectionWithPagination(
+      String projectId,
+      String collectionName,
+      InterruptibleConsumer<QueryDocumentSnapshot> documentProcessor)
+      throws InterruptedException {
     final Firestore db = FireStoreProject.get(projectId).getFirestore();
-    ;
     final CollectionReference collection = db.collection(collectionName);
-    return collection.get().get();
+    int batchSize = configurationService.getParameterValue(ConfigEnum.FIRESTORE_QUERY_BATCH_SIZE);
+
+    int batchCount = 0;
+    List<QueryDocumentSnapshot> documents = new ArrayList<>();
+    do {
+      QueryDocumentSnapshot lastDocument =
+          documents.size() > 0 ? documents.get(documents.size() - 1) : null;
+
+      documents =
+          fireStoreUtils.runTransactionWithRetry(
+              db,
+              xn -> {
+                Query query = collection.limit(batchSize);
+                if (lastDocument != null) {
+                  query = query.startAfter(lastDocument);
+                }
+                ApiFuture<QuerySnapshot> querySnapshot = xn.get(query);
+                return querySnapshot.get().getDocuments();
+              },
+              "processCollectionWithPagination",
+              " scanning " + batchSize + " items for collection: " + collectionName);
+      batchCount++;
+      if (!documents.isEmpty()) {
+        logger.info("Visiting batch {} of ~{} documents", batchCount, batchSize);
+        for (QueryDocumentSnapshot document : documents) {
+          documentProcessor.accept(document);
+        }
+      }
+    } while (documents.size() > 0);
   }
 
   public FSItem retrieveBySnapshotAndId(SnapshotProject snapshot, String fileId, int enumerateDepth)

--- a/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportDumpFirestoreStep.java
+++ b/src/main/java/bio/terra/service/snapshot/flight/export/SnapshotExportDumpFirestoreStep.java
@@ -16,14 +16,11 @@ import bio.terra.stairway.StepStatus;
 import bio.terra.stairway.exception.RetryException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.cloud.firestore.QueryDocumentSnapshot;
-import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 public class SnapshotExportDumpFirestoreStep implements Step {
   private final SnapshotService snapshotService;
@@ -52,23 +49,45 @@ public class SnapshotExportDumpFirestoreStep implements Step {
     context.getWorkingMap().put(SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_GSPATHS_FILENAME, fileName);
 
     try (GcsChannelWriter writer = makeWriterForDumpFile(context, fileName)) {
-      QuerySnapshot queryResult = fireStoreDao.retrieveFilesCollection(snapshot);
-      // note, creates an empty file for empty query result
-      for (QueryDocumentSnapshot d : queryResult.getDocuments()) {
-        // convert to snake_case here to match column names in BQ
-        Map<String, Object> dumpData =
-            Map.of(
-                PdaoConstant.PDAO_FIRESTORE_DUMP_FILE_ID_KEY,
-                    d.getData().get(FireStoreFile.FILE_ID_FIELD_NAME),
-                PdaoConstant.PDAO_FIRESTORE_DUMP_GSPATH_KEY,
-                    d.getData().get(FireStoreFile.GS_PATH_FIELD_NAME));
-        try {
-          writer.writeLine(objectMapper.writeValueAsString(dumpData));
-        } catch (JsonProcessingException e) {
-          return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, e);
+      // Use paginated retrieval to avoid query timeouts on large collections
+      String collectionName = String.format("%s-files", snapshot.getSourceDataset().getId());
+      String projectId = snapshot.getSourceDataset().getProjectResource().getGoogleProjectId();
+
+      try {
+        fireStoreDao.processCollectionWithPagination(
+            projectId,
+            collectionName,
+            d -> {
+              // convert to snake_case here to match column names in BQ
+              Map<String, Object> dumpData =
+                  Map.of(
+                      PdaoConstant.PDAO_FIRESTORE_DUMP_FILE_ID_KEY,
+                          d.getData().get(FireStoreFile.FILE_ID_FIELD_NAME),
+                      PdaoConstant.PDAO_FIRESTORE_DUMP_GSPATH_KEY,
+                          d.getData().get(FireStoreFile.GS_PATH_FIELD_NAME));
+              try {
+                writer.writeLine(objectMapper.writeValueAsString(dumpData));
+              } catch (JsonProcessingException e) {
+                throw new RuntimeException("Failed to write document to dump file", e);
+              } catch (IOException e) {
+                throw new RuntimeException("Failed to write document to dump file", e);
+              }
+            });
+        // note, creates an empty file for empty query result
+      } catch (RuntimeException e) {
+        // Handle JsonProcessingException or IOException wrapped in RuntimeException
+        Throwable cause = e.getCause();
+        if (cause instanceof JsonProcessingException) {
+          return new StepResult(StepStatus.STEP_RESULT_FAILURE_FATAL, (Exception) cause);
         }
+        if (cause instanceof IOException) {
+          return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, (Exception) cause);
+        }
+        throw e;
       }
-    } catch (IOException | ExecutionException e) {
+    } catch (IOException e) {
+      return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
+    } catch (RuntimeException e) {
       return new StepResult(StepStatus.STEP_RESULT_FAILURE_RETRY, e);
     }
     return StepResult.getStepResultSuccess();

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -2,225 +2,237 @@ package bio.terra.service.filedata.google.firestore;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
 
-import bio.terra.common.category.Unit;
+import bio.terra.app.configuration.ConnectedTestConfiguration;
+import bio.terra.common.EmbeddedDatabaseTest;
+import bio.terra.common.category.Connected;
+import bio.terra.common.fixtures.ConnectedOperations;
+import bio.terra.model.BillingProfileModel;
+import bio.terra.model.DatasetSummaryModel;
+import bio.terra.service.auth.iam.IamProviderInterface;
 import bio.terra.service.configuration.ConfigurationService;
-import com.google.cloud.firestore.CollectionReference;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.FileMetadataUtils;
+import bio.terra.service.filedata.SnapshotCompute;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.snapshot.Snapshot;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.Query;
-import com.google.cloud.firestore.QueryDocumentSnapshot;
-import com.google.cloud.firestore.QuerySnapshot;
+import com.google.common.collect.Streams;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(MockitoExtension.class)
-@Tag(Unit.TAG)
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles({"google", "connectedtest"})
+@Tag(Connected.TAG)
+@EmbeddedDatabaseTest
 class FireStoreDaoTest {
+  @Autowired private FireStoreDirectoryDao directoryDao;
+  @Autowired private FireStoreFileDao fileDao;
+  @Autowired private FireStoreDao dao;
+  @Autowired private FireStoreUtils fireStoreUtils;
+  @Autowired private FireStoreDependencyDao fireStoreDependencyDao;
+  @Autowired private ConnectedOperations connectedOperations;
+  @Autowired private ConnectedTestConfiguration testConfig;
+  @MockitoBean private IamProviderInterface samService;
+  @Autowired private ConfigurationService configService;
 
-  @Mock private FireStoreDirectoryDao directoryDao;
-  @Mock private FireStoreFileDao fileDao;
-  @Mock private FireStoreUtils fireStoreUtils;
-  @Mock private ConfigurationService configurationService;
-  @Mock private FireStoreProject fireStoreProject;
-  @Mock private Firestore firestore;
-  @Mock private CollectionReference collectionReference;
-  @Mock private Query query;
-  @Mock private QuerySnapshot querySnapshot;
-  @Mock private QueryDocumentSnapshot document1;
-  @Mock private QueryDocumentSnapshot document2;
-  @Mock private QueryDocumentSnapshot document3;
-
-  private FireStoreDao fireStoreDao;
-  private static final String PROJECT_ID = "test-project";
-  private static final String COLLECTION_NAME = "test-collection";
-  private static final int BATCH_SIZE = 2;
+  private Firestore firestore;
+  private String datasetId;
+  private String snapshotId;
+  private Dataset dataset;
+  private Snapshot snapshot;
 
   @BeforeEach
-  void setUp() {
-    fireStoreDao =
-        new FireStoreDao(
-            directoryDao, fileDao, fireStoreUtils, configurationService, null); // performanceLogger
+  public void setup() throws Exception {
+    connectedOperations.stubOutSamCalls(samService);
+    configService.reset();
 
-    when(configurationService.getParameterValue(any()))
-        .thenReturn(BATCH_SIZE); 
-    when(firestore.collection(COLLECTION_NAME)).thenReturn(collectionReference);
-    when(collectionReference.limit(anyInt())).thenReturn(query);
-    when(fireStoreProject.getFirestore()).thenReturn(firestore);
+    // Create dataset so that we have a firestore instance to test with
+    BillingProfileModel billingProfile =
+        connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
+    DatasetSummaryModel summaryModel =
+        connectedOperations.createDataset(billingProfile, "dataset-minimal.json");
+    GoogleProjectResource projectResource =
+        new GoogleProjectResource().googleProjectId(summaryModel.getDataProject());
+    dataset = new Dataset().id(summaryModel.getId()).projectResource(projectResource);
+    datasetId = summaryModel.getId().toString();
+    var snapshotIdUUID = UUID.randomUUID();
+    snapshotId = snapshotIdUUID.toString();
+    snapshot = new Snapshot().id(snapshotIdUUID).projectResource(projectResource);
+
+    // real case will have separate dataset and snapshot instances
+    // But, we can share this firestore instance for this test
+    firestore = TestFirestoreProvider.getFirestore(summaryModel.getDataProject());
   }
 
-  @Test
-  void testProcessCollectionWithPagination_EmptyCollection() throws Exception {
-    // Setup: Empty collection
-    List<QueryDocumentSnapshot> emptyBatch = List.of();
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
-        .thenReturn(emptyBatch);
-
-    // Mock FireStoreProject static method
-    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
-      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
-
-      // Execute
-      AtomicInteger processedCount = new AtomicInteger(0);
-      fireStoreDao.processCollectionWithPagination(
-          PROJECT_ID,
-          COLLECTION_NAME,
-          doc -> {
-            processedCount.incrementAndGet();
-          });
-
-      // Verify
-      assertEquals(0, processedCount.get());
-      verify(fireStoreUtils, times(1))
-          .runTransactionWithRetry(
-              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+  @AfterEach
+  public void cleanup() throws Exception {
+    if (datasetId != null) {
+      directoryDao.deleteDirectoryEntriesFromCollection(firestore, datasetId);
+      directoryDao.deleteDirectoryEntriesFromCollection(firestore, snapshotId);
+      fireStoreDependencyDao.deleteSnapshotFileDependencies(dataset, snapshotId);
+      fileDao.deleteFilesFromDataset(firestore, datasetId, f -> {});
     }
+    connectedOperations.teardown();
   }
 
+  // Test for snapshot file system
+  // collectionId is the datasetId
+  // snapshotId is obvious
+  // - create dataset file system
+  // - create subset snapshot file system
+  // - do the compute and validate
+  // Use binary for the sizes so each size combo will be unique
   @Test
-  void testProcessCollectionWithPagination_LargeCollection() throws Exception {
-    // Setup: 5 documents across 3 batches (2, 2, 1)
-    QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
-    QueryDocumentSnapshot doc2 = mock(QueryDocumentSnapshot.class);
-    QueryDocumentSnapshot doc3 = mock(QueryDocumentSnapshot.class);
-    QueryDocumentSnapshot doc4 = mock(QueryDocumentSnapshot.class);
-    QueryDocumentSnapshot doc5 = mock(QueryDocumentSnapshot.class);
+  void snapshotTest() throws Exception {
 
-    List<QueryDocumentSnapshot> batch1 = List.of(doc1, doc2);
-    List<QueryDocumentSnapshot> batch2 = List.of(doc3, doc4);
-    List<QueryDocumentSnapshot> batch3 = List.of(doc5);
-    List<QueryDocumentSnapshot> emptyBatch = List.of();
+    // Make files that will be in the snapshot
+    List<FireStoreDirectoryEntry> snapObjects = new ArrayList<>();
+    snapObjects.add(makeFileObject(datasetId, "/adir/A1", 1));
+    snapObjects.add(makeFileObject(datasetId, "/adir/bdir/B1", 2));
+    snapObjects.add(makeFileObject(datasetId, "/adir/bdir/cdir/C1", 4));
+    snapObjects.add(makeFileObject(datasetId, "/adir/bdir/cdir/C2", 8));
 
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
-        .thenReturn(batch1, batch2, batch3, emptyBatch);
+    // And some files that won't be in the snapshot
+    List<FireStoreDirectoryEntry> dsetObjects = new ArrayList<>();
+    dsetObjects.add(makeFileObject(datasetId, "/adir/bdir/B2", 16));
+    dsetObjects.add(makeFileObject(datasetId, "/adir/A2", 32));
 
-    // Mock startAfter for subsequent batches
-    Query query2 = mock(Query.class);
-    Query query3 = mock(Query.class);
-    when(query.startAfter(doc2)).thenReturn(query2);
-    when(query2.limit(BATCH_SIZE)).thenReturn(query2);
-    when(query2.startAfter(doc4)).thenReturn(query3);
-    when(query3.limit(BATCH_SIZE)).thenReturn(query3);
+    List<String> dsfileIdList =
+        Streams.concat(
+                dsetObjects.stream().map(FireStoreDirectoryEntry::getFileId),
+                snapObjects.stream().map(FireStoreDirectoryEntry::getFileId))
+            .toList();
 
-    // Mock FireStoreProject static method
-    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
-      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
-
-      // Execute
-      List<QueryDocumentSnapshot> processedDocuments = new ArrayList<>();
-      fireStoreDao.processCollectionWithPagination(
-          PROJECT_ID,
-          COLLECTION_NAME,
-          doc -> {
-            processedDocuments.add(doc);
-          });
-
-      // Verify
-      assertEquals(5, processedDocuments.size());
-      verify(fireStoreUtils, times(4))
-          .runTransactionWithRetry(
-              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+    // Make the dataset file system
+    List<FireStoreDirectoryEntry> fileObjects = new ArrayList<>(snapObjects);
+    fileObjects.addAll(dsetObjects);
+    for (FireStoreDirectoryEntry fireStoreDirectoryEntry : fileObjects) {
+      directoryDao.createDirectoryEntry(firestore, datasetId, fireStoreDirectoryEntry);
     }
+
+    // Make the snapshot file system
+    List<String> snapfileIdList =
+        snapObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
+    directoryDao.addEntriesToSnapshot(
+        firestore, datasetId, "dataset", firestore, snapshotId, snapfileIdList, false);
+
+    // Validate we can lookup files in the snapshot
+    for (FireStoreDirectoryEntry dsetObject : snapObjects) {
+      FireStoreDirectoryEntry snapObject =
+          directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
+      assertThat("objectId matches", snapObject.getFileId(), equalTo(dsetObject.getFileId()));
+      assertThat("path does not match", snapObject.getPath(), not(dsetObject.getPath()));
+    }
+
+    // ------ test FireStoreDependencyDao ----
+    // Before setting up the dependency file system, assert datasetHasSnapshotReference returns
+    // false
+    boolean noDependencies = fireStoreDependencyDao.datasetHasSnapshotReference(dataset);
+    assertThat("Dataset should not yet have dependencies", noDependencies, is(false));
+
+    // Create dependency file system
+    fireStoreDependencyDao.storeSnapshotFileDependencies(dataset, snapshotId, snapfileIdList);
+
+    // Snapshot and File Dependency should now exist for dataset
+    boolean hasReference = fireStoreDependencyDao.datasetHasSnapshotReference(dataset);
+    assertThat("Dataset should have dependencies", hasReference);
+
+    List<String> snapshotReferenceIds =
+        fireStoreDependencyDao.getFileSnapshotReferences(dataset, snapObjects.get(0).getFileId());
+    assertEquals(List.of(snapshotId), snapshotReferenceIds);
+
+    // Validate dataset files do not have references
+    List<String> noSnapshotReferenceIds =
+        fireStoreDependencyDao.getFileSnapshotReferences(dataset, dsetObjects.get(0).getFileId());
+    assertThat(
+        "No dependency on files not referenced in snapshot", noSnapshotReferenceIds.size(), is(0));
+
+    // Validate we cannot lookup dataset files in the snapshot
+    for (FireStoreDirectoryEntry dsetObject : dsetObjects) {
+      FireStoreDirectoryEntry snapObject =
+          directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
+      assertThat("object not found in snapshot", snapObject, is(nullValue()));
+    }
+
+    // Compute the size and checksums
+    FireStoreDirectoryEntry topDir = directoryDao.retrieveByPath(firestore, snapshotId, "/");
+    List<FireStoreDirectoryEntry> updateBatch = new ArrayList<>();
+    FireStoreDao.FirestoreComputeHelper helper = dao.getHelper(firestore, firestore, snapshotId);
+    SnapshotCompute.computeDirectory(helper, topDir, updateBatch);
+    directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
+
+    // Check the accumulated size on the root dir
+    FireStoreDirectoryEntry snapObject = directoryDao.retrieveByPath(firestore, snapshotId, "/");
+    assertThat("Total size is correct", snapObject.getSize(), equalTo(15L));
+
+    // Check that we can retrieve all with or without directories
+    assertThat(
+        "all dataset files and directories can be returned",
+        dao.retrieveAllFileIds(dataset, true),
+        hasSize(10));
+    assertThat(
+        "all dataset files (only) can be returned",
+        dao.retrieveAllFileIds(dataset, false).stream().sorted().toList(),
+        equalTo(dsfileIdList.stream().sorted().toList()));
+    assertThat(
+        "all snapshot files and directories can be returned",
+        dao.retrieveAllFileIds(snapshot, true),
+        hasSize(9));
+    assertThat(
+        "all snapshot files (only) can be returned",
+        dao.retrieveAllFileIds(snapshot, false).stream().sorted().toList(),
+        equalTo(snapfileIdList.stream().sorted().toList()));
   }
 
-  @Test
-  void testProcessCollectionWithPagination_InterruptedException() throws Exception {
-    // Setup: Throw InterruptedException from runTransactionWithRetry
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
-        .thenThrow(new InterruptedException("Test interruption"));
+  private FireStoreDirectoryEntry makeFileObject(String datasetId, String fullPath, long size)
+      throws InterruptedException {
 
-    // Mock FireStoreProject static method
-    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
-      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+    String fileId = UUID.randomUUID().toString();
 
-      // Execute & Verify
-      org.junit.jupiter.api.Assertions.assertThrows(
-          InterruptedException.class,
-          () ->
-              fireStoreDao.processCollectionWithPagination(PROJECT_ID, COLLECTION_NAME, doc -> {}));
-    }
-  }
+    FireStoreFile newFile =
+        new FireStoreFile()
+            .fileId(fileId)
+            .mimeType("application/test")
+            .description("test")
+            .bucketResourceId("test")
+            .fileCreatedDate(Instant.now().toString())
+            .gspath("gs://" + datasetId + "/" + fileId)
+            .checksumCrc32c(SnapshotCompute.computeCrc32c(fullPath))
+            .checksumMd5(SnapshotCompute.computeMd5(fullPath))
+            .userSpecifiedMd5(false)
+            .size(size);
 
-  @Test
-  void testProcessCollectionWithPagination_DocumentProcessorThrowsInterruptedException()
-      throws Exception {
-    // Setup: First batch with documents, processor throws InterruptedException
-    List<QueryDocumentSnapshot> firstBatch = List.of(document1, document2);
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
-        .thenReturn(firstBatch);
+    fileDao.upsertFileMetadata(firestore, datasetId, newFile);
 
-    // Mock FireStoreProject static method
-    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
-      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
-
-      // Execute & Verify: DocumentProcessor throws InterruptedException
-      org.junit.jupiter.api.Assertions.assertThrows(
-          InterruptedException.class,
-          () ->
-              fireStoreDao.processCollectionWithPagination(
-                  PROJECT_ID,
-                  COLLECTION_NAME,
-                  doc -> {
-                    throw new InterruptedException("Processor interrupted");
-                  }));
-    }
-  }
-
-  @Test
-  void testProcessCollectionWithPagination_BatchSizeEqualsDocumentCount() throws Exception {
-    // Setup: Batch size equals document count (2 docs, batch size 2)
-    // First batch has exactly batchSize documents, second batch is empty
-    List<QueryDocumentSnapshot> fullBatch = List.of(document1, document2);
-    List<QueryDocumentSnapshot> emptyBatch = List.of();
-
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
-        .thenReturn(fullBatch, emptyBatch);
-
-    // Mock startAfter for second batch (empty)
-    Query queryWithStartAfter = mock(Query.class);
-    when(query.startAfter(document2)).thenReturn(queryWithStartAfter);
-    when(queryWithStartAfter.limit(BATCH_SIZE)).thenReturn(queryWithStartAfter);
-
-    // Mock FireStoreProject static method
-    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
-      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
-
-      // Execute
-      List<QueryDocumentSnapshot> processedDocuments = new ArrayList<>();
-      fireStoreDao.processCollectionWithPagination(
-          PROJECT_ID,
-          COLLECTION_NAME,
-          doc -> {
-            processedDocuments.add(doc);
-          });
-
-      // Verify: All documents processed, empty batch detected correctly
-      assertEquals(2, processedDocuments.size());
-      assertThat(processedDocuments.get(0), equalTo(document1));
-      assertThat(processedDocuments.get(1), equalTo(document2));
-
-      // Verify: Two calls - first batch and empty batch check
-      verify(fireStoreUtils, times(2))
-          .runTransactionWithRetry(
-              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
-      verify(query, times(1)).startAfter(document2); // Called for second batch (empty)
-    }
+    return new FireStoreDirectoryEntry()
+        .fileId(fileId)
+        .isFileRef(true)
+        .path(FileMetadataUtils.getDirectoryPath(fullPath))
+        .name(FileMetadataUtils.getName(fullPath))
+        .datasetId(datasetId)
+        .size(size)
+        .checksumCrc32c(SnapshotCompute.computeCrc32c(fullPath))
+        .checksumMd5(SnapshotCompute.computeMd5(fullPath));
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoTest.java
@@ -2,237 +2,225 @@ package bio.terra.service.filedata.google.firestore;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
-import bio.terra.app.configuration.ConnectedTestConfiguration;
-import bio.terra.common.EmbeddedDatabaseTest;
-import bio.terra.common.category.Connected;
-import bio.terra.common.fixtures.ConnectedOperations;
-import bio.terra.model.BillingProfileModel;
-import bio.terra.model.DatasetSummaryModel;
-import bio.terra.service.auth.iam.IamProviderInterface;
+import bio.terra.common.category.Unit;
 import bio.terra.service.configuration.ConfigurationService;
-import bio.terra.service.dataset.Dataset;
-import bio.terra.service.filedata.FileMetadataUtils;
-import bio.terra.service.filedata.SnapshotCompute;
-import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
-import bio.terra.service.snapshot.Snapshot;
+import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
-import com.google.common.collect.Streams;
-import java.time.Instant;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles({"google", "connectedtest"})
-@Tag(Connected.TAG)
-@EmbeddedDatabaseTest
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
 class FireStoreDaoTest {
-  @Autowired private FireStoreDirectoryDao directoryDao;
-  @Autowired private FireStoreFileDao fileDao;
-  @Autowired private FireStoreDao dao;
-  @Autowired private FireStoreUtils fireStoreUtils;
-  @Autowired private FireStoreDependencyDao fireStoreDependencyDao;
-  @Autowired private ConnectedOperations connectedOperations;
-  @Autowired private ConnectedTestConfiguration testConfig;
-  @MockitoBean private IamProviderInterface samService;
-  @Autowired private ConfigurationService configService;
 
-  private Firestore firestore;
-  private String datasetId;
-  private String snapshotId;
-  private Dataset dataset;
-  private Snapshot snapshot;
+  @Mock private FireStoreDirectoryDao directoryDao;
+  @Mock private FireStoreFileDao fileDao;
+  @Mock private FireStoreUtils fireStoreUtils;
+  @Mock private ConfigurationService configurationService;
+  @Mock private FireStoreProject fireStoreProject;
+  @Mock private Firestore firestore;
+  @Mock private CollectionReference collectionReference;
+  @Mock private Query query;
+  @Mock private QuerySnapshot querySnapshot;
+  @Mock private QueryDocumentSnapshot document1;
+  @Mock private QueryDocumentSnapshot document2;
+  @Mock private QueryDocumentSnapshot document3;
+
+  private FireStoreDao fireStoreDao;
+  private static final String PROJECT_ID = "test-project";
+  private static final String COLLECTION_NAME = "test-collection";
+  private static final int BATCH_SIZE = 2;
 
   @BeforeEach
-  public void setup() throws Exception {
-    connectedOperations.stubOutSamCalls(samService);
-    configService.reset();
+  void setUp() {
+    fireStoreDao =
+        new FireStoreDao(
+            directoryDao, fileDao, fireStoreUtils, configurationService, null); // performanceLogger
 
-    // Create dataset so that we have a firestore instance to test with
-    BillingProfileModel billingProfile =
-        connectedOperations.createProfileForAccount(testConfig.getGoogleBillingAccountId());
-    DatasetSummaryModel summaryModel =
-        connectedOperations.createDataset(billingProfile, "dataset-minimal.json");
-    GoogleProjectResource projectResource =
-        new GoogleProjectResource().googleProjectId(summaryModel.getDataProject());
-    dataset = new Dataset().id(summaryModel.getId()).projectResource(projectResource);
-    datasetId = summaryModel.getId().toString();
-    var snapshotIdUUID = UUID.randomUUID();
-    snapshotId = snapshotIdUUID.toString();
-    snapshot = new Snapshot().id(snapshotIdUUID).projectResource(projectResource);
-
-    // real case will have separate dataset and snapshot instances
-    // But, we can share this firestore instance for this test
-    firestore = TestFirestoreProvider.getFirestore(summaryModel.getDataProject());
+    when(configurationService.getParameterValue(any()))
+        .thenReturn(BATCH_SIZE); 
+    when(firestore.collection(COLLECTION_NAME)).thenReturn(collectionReference);
+    when(collectionReference.limit(anyInt())).thenReturn(query);
+    when(fireStoreProject.getFirestore()).thenReturn(firestore);
   }
 
-  @AfterEach
-  public void cleanup() throws Exception {
-    if (datasetId != null) {
-      directoryDao.deleteDirectoryEntriesFromCollection(firestore, datasetId);
-      directoryDao.deleteDirectoryEntriesFromCollection(firestore, snapshotId);
-      fireStoreDependencyDao.deleteSnapshotFileDependencies(dataset, snapshotId);
-      fileDao.deleteFilesFromDataset(firestore, datasetId, f -> {});
-    }
-    connectedOperations.teardown();
-  }
-
-  // Test for snapshot file system
-  // collectionId is the datasetId
-  // snapshotId is obvious
-  // - create dataset file system
-  // - create subset snapshot file system
-  // - do the compute and validate
-  // Use binary for the sizes so each size combo will be unique
   @Test
-  void snapshotTest() throws Exception {
+  void testProcessCollectionWithPagination_EmptyCollection() throws Exception {
+    // Setup: Empty collection
+    List<QueryDocumentSnapshot> emptyBatch = List.of();
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(emptyBatch);
 
-    // Make files that will be in the snapshot
-    List<FireStoreDirectoryEntry> snapObjects = new ArrayList<>();
-    snapObjects.add(makeFileObject(datasetId, "/adir/A1", 1));
-    snapObjects.add(makeFileObject(datasetId, "/adir/bdir/B1", 2));
-    snapObjects.add(makeFileObject(datasetId, "/adir/bdir/cdir/C1", 4));
-    snapObjects.add(makeFileObject(datasetId, "/adir/bdir/cdir/C2", 8));
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
 
-    // And some files that won't be in the snapshot
-    List<FireStoreDirectoryEntry> dsetObjects = new ArrayList<>();
-    dsetObjects.add(makeFileObject(datasetId, "/adir/bdir/B2", 16));
-    dsetObjects.add(makeFileObject(datasetId, "/adir/A2", 32));
+      // Execute
+      AtomicInteger processedCount = new AtomicInteger(0);
+      fireStoreDao.processCollectionWithPagination(
+          PROJECT_ID,
+          COLLECTION_NAME,
+          doc -> {
+            processedCount.incrementAndGet();
+          });
 
-    List<String> dsfileIdList =
-        Streams.concat(
-                dsetObjects.stream().map(FireStoreDirectoryEntry::getFileId),
-                snapObjects.stream().map(FireStoreDirectoryEntry::getFileId))
-            .toList();
-
-    // Make the dataset file system
-    List<FireStoreDirectoryEntry> fileObjects = new ArrayList<>(snapObjects);
-    fileObjects.addAll(dsetObjects);
-    for (FireStoreDirectoryEntry fireStoreDirectoryEntry : fileObjects) {
-      directoryDao.createDirectoryEntry(firestore, datasetId, fireStoreDirectoryEntry);
+      // Verify
+      assertEquals(0, processedCount.get());
+      verify(fireStoreUtils, times(1))
+          .runTransactionWithRetry(
+              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
     }
-
-    // Make the snapshot file system
-    List<String> snapfileIdList =
-        snapObjects.stream().map(FireStoreDirectoryEntry::getFileId).toList();
-    directoryDao.addEntriesToSnapshot(
-        firestore, datasetId, "dataset", firestore, snapshotId, snapfileIdList, false);
-
-    // Validate we can lookup files in the snapshot
-    for (FireStoreDirectoryEntry dsetObject : snapObjects) {
-      FireStoreDirectoryEntry snapObject =
-          directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
-      assertThat("objectId matches", snapObject.getFileId(), equalTo(dsetObject.getFileId()));
-      assertThat("path does not match", snapObject.getPath(), not(dsetObject.getPath()));
-    }
-
-    // ------ test FireStoreDependencyDao ----
-    // Before setting up the dependency file system, assert datasetHasSnapshotReference returns
-    // false
-    boolean noDependencies = fireStoreDependencyDao.datasetHasSnapshotReference(dataset);
-    assertThat("Dataset should not yet have dependencies", noDependencies, is(false));
-
-    // Create dependency file system
-    fireStoreDependencyDao.storeSnapshotFileDependencies(dataset, snapshotId, snapfileIdList);
-
-    // Snapshot and File Dependency should now exist for dataset
-    boolean hasReference = fireStoreDependencyDao.datasetHasSnapshotReference(dataset);
-    assertThat("Dataset should have dependencies", hasReference);
-
-    List<String> snapshotReferenceIds =
-        fireStoreDependencyDao.getFileSnapshotReferences(dataset, snapObjects.get(0).getFileId());
-    assertEquals(List.of(snapshotId), snapshotReferenceIds);
-
-    // Validate dataset files do not have references
-    List<String> noSnapshotReferenceIds =
-        fireStoreDependencyDao.getFileSnapshotReferences(dataset, dsetObjects.get(0).getFileId());
-    assertThat(
-        "No dependency on files not referenced in snapshot", noSnapshotReferenceIds.size(), is(0));
-
-    // Validate we cannot lookup dataset files in the snapshot
-    for (FireStoreDirectoryEntry dsetObject : dsetObjects) {
-      FireStoreDirectoryEntry snapObject =
-          directoryDao.retrieveById(firestore, snapshotId, dsetObject.getFileId());
-      assertThat("object not found in snapshot", snapObject, is(nullValue()));
-    }
-
-    // Compute the size and checksums
-    FireStoreDirectoryEntry topDir = directoryDao.retrieveByPath(firestore, snapshotId, "/");
-    List<FireStoreDirectoryEntry> updateBatch = new ArrayList<>();
-    FireStoreDao.FirestoreComputeHelper helper = dao.getHelper(firestore, firestore, snapshotId);
-    SnapshotCompute.computeDirectory(helper, topDir, updateBatch);
-    directoryDao.batchStoreDirectoryEntry(firestore, snapshotId, updateBatch);
-
-    // Check the accumulated size on the root dir
-    FireStoreDirectoryEntry snapObject = directoryDao.retrieveByPath(firestore, snapshotId, "/");
-    assertThat("Total size is correct", snapObject.getSize(), equalTo(15L));
-
-    // Check that we can retrieve all with or without directories
-    assertThat(
-        "all dataset files and directories can be returned",
-        dao.retrieveAllFileIds(dataset, true),
-        hasSize(10));
-    assertThat(
-        "all dataset files (only) can be returned",
-        dao.retrieveAllFileIds(dataset, false).stream().sorted().toList(),
-        equalTo(dsfileIdList.stream().sorted().toList()));
-    assertThat(
-        "all snapshot files and directories can be returned",
-        dao.retrieveAllFileIds(snapshot, true),
-        hasSize(9));
-    assertThat(
-        "all snapshot files (only) can be returned",
-        dao.retrieveAllFileIds(snapshot, false).stream().sorted().toList(),
-        equalTo(snapfileIdList.stream().sorted().toList()));
   }
 
-  private FireStoreDirectoryEntry makeFileObject(String datasetId, String fullPath, long size)
-      throws InterruptedException {
+  @Test
+  void testProcessCollectionWithPagination_LargeCollection() throws Exception {
+    // Setup: 5 documents across 3 batches (2, 2, 1)
+    QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc2 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc3 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc4 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc5 = mock(QueryDocumentSnapshot.class);
 
-    String fileId = UUID.randomUUID().toString();
+    List<QueryDocumentSnapshot> batch1 = List.of(doc1, doc2);
+    List<QueryDocumentSnapshot> batch2 = List.of(doc3, doc4);
+    List<QueryDocumentSnapshot> batch3 = List.of(doc5);
+    List<QueryDocumentSnapshot> emptyBatch = List.of();
 
-    FireStoreFile newFile =
-        new FireStoreFile()
-            .fileId(fileId)
-            .mimeType("application/test")
-            .description("test")
-            .bucketResourceId("test")
-            .fileCreatedDate(Instant.now().toString())
-            .gspath("gs://" + datasetId + "/" + fileId)
-            .checksumCrc32c(SnapshotCompute.computeCrc32c(fullPath))
-            .checksumMd5(SnapshotCompute.computeMd5(fullPath))
-            .userSpecifiedMd5(false)
-            .size(size);
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(batch1, batch2, batch3, emptyBatch);
 
-    fileDao.upsertFileMetadata(firestore, datasetId, newFile);
+    // Mock startAfter for subsequent batches
+    Query query2 = mock(Query.class);
+    Query query3 = mock(Query.class);
+    when(query.startAfter(doc2)).thenReturn(query2);
+    when(query2.limit(BATCH_SIZE)).thenReturn(query2);
+    when(query2.startAfter(doc4)).thenReturn(query3);
+    when(query3.limit(BATCH_SIZE)).thenReturn(query3);
 
-    return new FireStoreDirectoryEntry()
-        .fileId(fileId)
-        .isFileRef(true)
-        .path(FileMetadataUtils.getDirectoryPath(fullPath))
-        .name(FileMetadataUtils.getName(fullPath))
-        .datasetId(datasetId)
-        .size(size)
-        .checksumCrc32c(SnapshotCompute.computeCrc32c(fullPath))
-        .checksumMd5(SnapshotCompute.computeMd5(fullPath));
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute
+      List<QueryDocumentSnapshot> processedDocuments = new ArrayList<>();
+      fireStoreDao.processCollectionWithPagination(
+          PROJECT_ID,
+          COLLECTION_NAME,
+          doc -> {
+            processedDocuments.add(doc);
+          });
+
+      // Verify
+      assertEquals(5, processedDocuments.size());
+      verify(fireStoreUtils, times(4))
+          .runTransactionWithRetry(
+              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_InterruptedException() throws Exception {
+    // Setup: Throw InterruptedException from runTransactionWithRetry
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenThrow(new InterruptedException("Test interruption"));
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute & Verify
+      org.junit.jupiter.api.Assertions.assertThrows(
+          InterruptedException.class,
+          () ->
+              fireStoreDao.processCollectionWithPagination(PROJECT_ID, COLLECTION_NAME, doc -> {}));
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_DocumentProcessorThrowsInterruptedException()
+      throws Exception {
+    // Setup: First batch with documents, processor throws InterruptedException
+    List<QueryDocumentSnapshot> firstBatch = List.of(document1, document2);
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(firstBatch);
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute & Verify: DocumentProcessor throws InterruptedException
+      org.junit.jupiter.api.Assertions.assertThrows(
+          InterruptedException.class,
+          () ->
+              fireStoreDao.processCollectionWithPagination(
+                  PROJECT_ID,
+                  COLLECTION_NAME,
+                  doc -> {
+                    throw new InterruptedException("Processor interrupted");
+                  }));
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_BatchSizeEqualsDocumentCount() throws Exception {
+    // Setup: Batch size equals document count (2 docs, batch size 2)
+    // First batch has exactly batchSize documents, second batch is empty
+    List<QueryDocumentSnapshot> fullBatch = List.of(document1, document2);
+    List<QueryDocumentSnapshot> emptyBatch = List.of();
+
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(fullBatch, emptyBatch);
+
+    // Mock startAfter for second batch (empty)
+    Query queryWithStartAfter = mock(Query.class);
+    when(query.startAfter(document2)).thenReturn(queryWithStartAfter);
+    when(queryWithStartAfter.limit(BATCH_SIZE)).thenReturn(queryWithStartAfter);
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute
+      List<QueryDocumentSnapshot> processedDocuments = new ArrayList<>();
+      fireStoreDao.processCollectionWithPagination(
+          PROJECT_ID,
+          COLLECTION_NAME,
+          doc -> {
+            processedDocuments.add(doc);
+          });
+
+      // Verify: All documents processed, empty batch detected correctly
+      assertEquals(2, processedDocuments.size());
+      assertThat(processedDocuments.get(0), equalTo(document1));
+      assertThat(processedDocuments.get(1), equalTo(document2));
+
+      // Verify: Two calls - first batch and empty batch check
+      verify(fireStoreUtils, times(2))
+          .runTransactionWithRetry(
+              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+      verify(query, times(1)).startAfter(document2); // Called for second batch (empty)
+    }
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
@@ -54,8 +54,7 @@ class FireStoreDaoUnitTest {
         new FireStoreDao(
             directoryDao, fileDao, fireStoreUtils, configurationService, null); // performanceLogger
 
-    when(configurationService.getParameterValue(any()))
-        .thenReturn(BATCH_SIZE); 
+    when(configurationService.getParameterValue(any())).thenReturn(BATCH_SIZE);
     when(firestore.collection(COLLECTION_NAME)).thenReturn(collectionReference);
     when(collectionReference.limit(anyInt())).thenReturn(query);
     when(fireStoreProject.getFirestore()).thenReturn(firestore);

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
@@ -10,7 +10,9 @@ import static org.mockito.Mockito.*;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.configuration.ConfigurationService;
+import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +35,8 @@ class FireStoreDaoUnitTest {
   @Mock private ConfigurationService configurationService;
   @Mock private FireStoreProject fireStoreProject;
   @Mock private Firestore firestore;
+  @Mock private CollectionReference collectionReference;
+  @Mock private Query query;
   @Mock private QueryDocumentSnapshot document1;
   @Mock private QueryDocumentSnapshot document2;
   @Mock private QueryDocumentSnapshot document3;
@@ -52,12 +56,23 @@ class FireStoreDaoUnitTest {
     when(fireStoreProject.getFirestore()).thenReturn(firestore);
   }
 
+  private void setupQueryMocks(boolean needsStartAfter) {
+    when(firestore.collection(COLLECTION_NAME)).thenReturn(collectionReference);
+    when(collectionReference.select(anyString(), anyString())).thenReturn(query);
+    when(query.getFirestore()).thenReturn(firestore);
+    when(query.offset(anyInt())).thenReturn(query);
+    when(query.limit(anyInt())).thenReturn(query);
+    if (needsStartAfter) {
+      when(query.startAfter(any(QueryDocumentSnapshot.class))).thenReturn(query);
+    }
+  }
+
   @Test
   void testProcessCollectionWithPagination_EmptyCollection() throws Exception {
     // Setup: Empty collection
+    setupQueryMocks(false);
     List<QueryDocumentSnapshot> emptyBatch = List.of();
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+    when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString()))
         .thenReturn(emptyBatch);
 
     // Mock FireStoreProject static method
@@ -76,14 +91,14 @@ class FireStoreDaoUnitTest {
       // Verify
       assertEquals(0, processedCount.get());
       verify(fireStoreUtils, times(1))
-          .runTransactionWithRetry(
-              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+          .runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString());
     }
   }
 
   @Test
   void testProcessCollectionWithPagination_LargeCollection() throws Exception {
     // Setup: 5 documents across 3 batches (2, 2, 1)
+    setupQueryMocks(true);
     QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
     QueryDocumentSnapshot doc2 = mock(QueryDocumentSnapshot.class);
     QueryDocumentSnapshot doc3 = mock(QueryDocumentSnapshot.class);
@@ -93,11 +108,10 @@ class FireStoreDaoUnitTest {
     List<QueryDocumentSnapshot> batch1 = List.of(doc1, doc2);
     List<QueryDocumentSnapshot> batch2 = List.of(doc3, doc4);
     List<QueryDocumentSnapshot> batch3 = List.of(doc5);
-    List<QueryDocumentSnapshot> emptyBatch = List.of();
+    // After batch3 (1 doc < batchSize 2), iterator returns null without another call
 
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
-        .thenReturn(batch1, batch2, batch3, emptyBatch);
+    when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString()))
+        .thenReturn(batch1, batch2, batch3);
 
     // Mock FireStoreProject static method
     try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
@@ -114,17 +128,18 @@ class FireStoreDaoUnitTest {
 
       // Verify
       assertEquals(5, processedDocuments.size());
-      verify(fireStoreUtils, times(4))
-          .runTransactionWithRetry(
-              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+      // Iterator makes 3 calls: batch1 (2 docs), batch2 (2 docs), batch3 (1 doc)
+      // After batch3, it returns null without another call since listSize < batchSize
+      verify(fireStoreUtils, times(3))
+          .runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString());
     }
   }
 
   @Test
   void testProcessCollectionWithPagination_InterruptedException() throws Exception {
     // Setup: Throw InterruptedException from runTransactionWithRetry
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+    setupQueryMocks(false);
+    when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString()))
         .thenThrow(new InterruptedException("Test interruption"));
 
     // Mock FireStoreProject static method
@@ -143,9 +158,9 @@ class FireStoreDaoUnitTest {
   void testProcessCollectionWithPagination_DocumentProcessorThrowsInterruptedException()
       throws Exception {
     // Setup: First batch with documents, processor throws InterruptedException
+    setupQueryMocks(false);
     List<QueryDocumentSnapshot> firstBatch = List.of(document1, document2);
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+    when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString()))
         .thenReturn(firstBatch);
 
     // Mock FireStoreProject static method
@@ -169,11 +184,11 @@ class FireStoreDaoUnitTest {
   void testProcessCollectionWithPagination_BatchSizeEqualsDocumentCount() throws Exception {
     // Setup: Batch size equals document count (2 docs, batch size 2)
     // First batch has exactly batchSize documents, second batch is empty
+    setupQueryMocks(true);
     List<QueryDocumentSnapshot> fullBatch = List.of(document1, document2);
     List<QueryDocumentSnapshot> emptyBatch = List.of();
 
-    when(fireStoreUtils.runTransactionWithRetry(
-            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+    when(fireStoreUtils.runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString()))
         .thenReturn(fullBatch, emptyBatch);
 
     // Mock FireStoreProject static method
@@ -196,8 +211,7 @@ class FireStoreDaoUnitTest {
 
       // Verify: Two calls - first batch and empty batch check
       verify(fireStoreUtils, times(2))
-          .runTransactionWithRetry(
-              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+          .runTransactionWithRetry(eq(firestore), any(), eq("getBatch"), anyString());
     }
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
@@ -10,11 +10,8 @@ import static org.mockito.Mockito.*;
 
 import bio.terra.common.category.Unit;
 import bio.terra.service.configuration.ConfigurationService;
-import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.Firestore;
-import com.google.cloud.firestore.Query;
 import com.google.cloud.firestore.QueryDocumentSnapshot;
-import com.google.cloud.firestore.QuerySnapshot;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -36,9 +33,6 @@ class FireStoreDaoUnitTest {
   @Mock private ConfigurationService configurationService;
   @Mock private FireStoreProject fireStoreProject;
   @Mock private Firestore firestore;
-  @Mock private CollectionReference collectionReference;
-  @Mock private Query query;
-  @Mock private QuerySnapshot querySnapshot;
   @Mock private QueryDocumentSnapshot document1;
   @Mock private QueryDocumentSnapshot document2;
   @Mock private QueryDocumentSnapshot document3;
@@ -55,8 +49,6 @@ class FireStoreDaoUnitTest {
             directoryDao, fileDao, fireStoreUtils, configurationService, null); // performanceLogger
 
     when(configurationService.getParameterValue(any())).thenReturn(BATCH_SIZE);
-    when(firestore.collection(COLLECTION_NAME)).thenReturn(collectionReference);
-    when(collectionReference.limit(anyInt())).thenReturn(query);
     when(fireStoreProject.getFirestore()).thenReturn(firestore);
   }
 
@@ -106,14 +98,6 @@ class FireStoreDaoUnitTest {
     when(fireStoreUtils.runTransactionWithRetry(
             eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
         .thenReturn(batch1, batch2, batch3, emptyBatch);
-
-    // Mock startAfter for subsequent batches
-    Query query2 = mock(Query.class);
-    Query query3 = mock(Query.class);
-    when(query.startAfter(doc2)).thenReturn(query2);
-    when(query2.limit(BATCH_SIZE)).thenReturn(query2);
-    when(query2.startAfter(doc4)).thenReturn(query3);
-    when(query3.limit(BATCH_SIZE)).thenReturn(query3);
 
     // Mock FireStoreProject static method
     try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
@@ -192,11 +176,6 @@ class FireStoreDaoUnitTest {
             eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
         .thenReturn(fullBatch, emptyBatch);
 
-    // Mock startAfter for second batch (empty)
-    Query queryWithStartAfter = mock(Query.class);
-    when(query.startAfter(document2)).thenReturn(queryWithStartAfter);
-    when(queryWithStartAfter.limit(BATCH_SIZE)).thenReturn(queryWithStartAfter);
-
     // Mock FireStoreProject static method
     try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
       mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
@@ -219,7 +198,6 @@ class FireStoreDaoUnitTest {
       verify(fireStoreUtils, times(2))
           .runTransactionWithRetry(
               eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
-      verify(query, times(1)).startAfter(document2); // Called for second batch (empty)
     }
   }
 }

--- a/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
+++ b/src/test/java/bio/terra/service/filedata/google/firestore/FireStoreDaoUnitTest.java
@@ -1,0 +1,226 @@
+package bio.terra.service.filedata.google.firestore;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.configuration.ConfigurationService;
+import com.google.cloud.firestore.CollectionReference;
+import com.google.cloud.firestore.Firestore;
+import com.google.cloud.firestore.Query;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.firestore.QuerySnapshot;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class FireStoreDaoUnitTest {
+
+  @Mock private FireStoreDirectoryDao directoryDao;
+  @Mock private FireStoreFileDao fileDao;
+  @Mock private FireStoreUtils fireStoreUtils;
+  @Mock private ConfigurationService configurationService;
+  @Mock private FireStoreProject fireStoreProject;
+  @Mock private Firestore firestore;
+  @Mock private CollectionReference collectionReference;
+  @Mock private Query query;
+  @Mock private QuerySnapshot querySnapshot;
+  @Mock private QueryDocumentSnapshot document1;
+  @Mock private QueryDocumentSnapshot document2;
+  @Mock private QueryDocumentSnapshot document3;
+
+  private FireStoreDao fireStoreDao;
+  private static final String PROJECT_ID = "test-project";
+  private static final String COLLECTION_NAME = "test-collection";
+  private static final int BATCH_SIZE = 2;
+
+  @BeforeEach
+  void setUp() {
+    fireStoreDao =
+        new FireStoreDao(
+            directoryDao, fileDao, fireStoreUtils, configurationService, null); // performanceLogger
+
+    when(configurationService.getParameterValue(any()))
+        .thenReturn(BATCH_SIZE); 
+    when(firestore.collection(COLLECTION_NAME)).thenReturn(collectionReference);
+    when(collectionReference.limit(anyInt())).thenReturn(query);
+    when(fireStoreProject.getFirestore()).thenReturn(firestore);
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_EmptyCollection() throws Exception {
+    // Setup: Empty collection
+    List<QueryDocumentSnapshot> emptyBatch = List.of();
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(emptyBatch);
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute
+      AtomicInteger processedCount = new AtomicInteger(0);
+      fireStoreDao.processCollectionWithPagination(
+          PROJECT_ID,
+          COLLECTION_NAME,
+          doc -> {
+            processedCount.incrementAndGet();
+          });
+
+      // Verify
+      assertEquals(0, processedCount.get());
+      verify(fireStoreUtils, times(1))
+          .runTransactionWithRetry(
+              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_LargeCollection() throws Exception {
+    // Setup: 5 documents across 3 batches (2, 2, 1)
+    QueryDocumentSnapshot doc1 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc2 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc3 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc4 = mock(QueryDocumentSnapshot.class);
+    QueryDocumentSnapshot doc5 = mock(QueryDocumentSnapshot.class);
+
+    List<QueryDocumentSnapshot> batch1 = List.of(doc1, doc2);
+    List<QueryDocumentSnapshot> batch2 = List.of(doc3, doc4);
+    List<QueryDocumentSnapshot> batch3 = List.of(doc5);
+    List<QueryDocumentSnapshot> emptyBatch = List.of();
+
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(batch1, batch2, batch3, emptyBatch);
+
+    // Mock startAfter for subsequent batches
+    Query query2 = mock(Query.class);
+    Query query3 = mock(Query.class);
+    when(query.startAfter(doc2)).thenReturn(query2);
+    when(query2.limit(BATCH_SIZE)).thenReturn(query2);
+    when(query2.startAfter(doc4)).thenReturn(query3);
+    when(query3.limit(BATCH_SIZE)).thenReturn(query3);
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute
+      List<QueryDocumentSnapshot> processedDocuments = new ArrayList<>();
+      fireStoreDao.processCollectionWithPagination(
+          PROJECT_ID,
+          COLLECTION_NAME,
+          doc -> {
+            processedDocuments.add(doc);
+          });
+
+      // Verify
+      assertEquals(5, processedDocuments.size());
+      verify(fireStoreUtils, times(4))
+          .runTransactionWithRetry(
+              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_InterruptedException() throws Exception {
+    // Setup: Throw InterruptedException from runTransactionWithRetry
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenThrow(new InterruptedException("Test interruption"));
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute & Verify
+      org.junit.jupiter.api.Assertions.assertThrows(
+          InterruptedException.class,
+          () ->
+              fireStoreDao.processCollectionWithPagination(PROJECT_ID, COLLECTION_NAME, doc -> {}));
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_DocumentProcessorThrowsInterruptedException()
+      throws Exception {
+    // Setup: First batch with documents, processor throws InterruptedException
+    List<QueryDocumentSnapshot> firstBatch = List.of(document1, document2);
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(firstBatch);
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute & Verify: DocumentProcessor throws InterruptedException
+      org.junit.jupiter.api.Assertions.assertThrows(
+          InterruptedException.class,
+          () ->
+              fireStoreDao.processCollectionWithPagination(
+                  PROJECT_ID,
+                  COLLECTION_NAME,
+                  doc -> {
+                    throw new InterruptedException("Processor interrupted");
+                  }));
+    }
+  }
+
+  @Test
+  void testProcessCollectionWithPagination_BatchSizeEqualsDocumentCount() throws Exception {
+    // Setup: Batch size equals document count (2 docs, batch size 2)
+    // First batch has exactly batchSize documents, second batch is empty
+    List<QueryDocumentSnapshot> fullBatch = List.of(document1, document2);
+    List<QueryDocumentSnapshot> emptyBatch = List.of();
+
+    when(fireStoreUtils.runTransactionWithRetry(
+            eq(firestore), any(), eq("processCollectionWithPagination"), anyString()))
+        .thenReturn(fullBatch, emptyBatch);
+
+    // Mock startAfter for second batch (empty)
+    Query queryWithStartAfter = mock(Query.class);
+    when(query.startAfter(document2)).thenReturn(queryWithStartAfter);
+    when(queryWithStartAfter.limit(BATCH_SIZE)).thenReturn(queryWithStartAfter);
+
+    // Mock FireStoreProject static method
+    try (MockedStatic<FireStoreProject> mockedStatic = mockStatic(FireStoreProject.class)) {
+      mockedStatic.when(() -> FireStoreProject.get(PROJECT_ID)).thenReturn(fireStoreProject);
+
+      // Execute
+      List<QueryDocumentSnapshot> processedDocuments = new ArrayList<>();
+      fireStoreDao.processCollectionWithPagination(
+          PROJECT_ID,
+          COLLECTION_NAME,
+          doc -> {
+            processedDocuments.add(doc);
+          });
+
+      // Verify: All documents processed, empty batch detected correctly
+      assertEquals(2, processedDocuments.size());
+      assertThat(processedDocuments.get(0), equalTo(document1));
+      assertThat(processedDocuments.get(1), equalTo(document2));
+
+      // Verify: Two calls - first batch and empty batch check
+      verify(fireStoreUtils, times(2))
+          .runTransactionWithRetry(
+              eq(firestore), any(), eq("processCollectionWithPagination"), anyString());
+      verify(query, times(1)).startAfter(document2); // Called for second batch (empty)
+    }
+  }
+}

--- a/src/test/java/bio/terra/service/snapshot/flight/export/SnapshotExportDumpFirestoreStepTest.java
+++ b/src/test/java/bio/terra/service/snapshot/flight/export/SnapshotExportDumpFirestoreStepTest.java
@@ -1,0 +1,388 @@
+package bio.terra.service.snapshot.flight.export;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import bio.terra.common.category.Unit;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.filedata.google.firestore.FireStoreDao;
+import bio.terra.service.filedata.google.firestore.FireStoreFile;
+import bio.terra.service.filedata.google.gcs.GcsChannelWriter;
+import bio.terra.service.filedata.google.gcs.GcsPdao;
+import bio.terra.service.resourcemanagement.google.GoogleBucketResource;
+import bio.terra.service.resourcemanagement.google.GoogleProjectResource;
+import bio.terra.service.snapshot.Snapshot;
+import bio.terra.service.snapshot.SnapshotService;
+import bio.terra.service.snapshot.SnapshotSource;
+import bio.terra.service.snapshot.exception.SnapshotNotFoundException;
+import bio.terra.service.snapshot.flight.SnapshotWorkingMapKeys;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.WriteChannel;
+import com.google.cloud.firestore.QueryDocumentSnapshot;
+import com.google.cloud.storage.BlobInfo;
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class SnapshotExportDumpFirestoreStepTest {
+
+  @Mock private SnapshotService snapshotService;
+  @Mock private FireStoreDao fireStoreDao;
+  @Mock private GcsPdao gcsPdao;
+  @Mock private FlightContext flightContext;
+  @Mock private GcsChannelWriter writer;
+  @Mock private QueryDocumentSnapshot document1;
+  @Mock private QueryDocumentSnapshot document2;
+
+  private SnapshotExportDumpFirestoreStep step;
+  private ObjectMapper objectMapper;
+  private UUID snapshotId;
+  private Snapshot snapshot;
+  private GoogleBucketResource exportBucket;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    snapshotId = UUID.randomUUID();
+    objectMapper = new ObjectMapper();
+    step =
+        new SnapshotExportDumpFirestoreStep(
+            snapshotService, fireStoreDao, gcsPdao, snapshotId, objectMapper);
+
+    // Setup snapshot
+    UUID datasetId = UUID.randomUUID();
+    GoogleProjectResource projectResource =
+        new GoogleProjectResource().googleProjectId("test-project");
+    Dataset dataset = new Dataset().id(datasetId).projectResource(projectResource);
+    snapshot =
+        new Snapshot()
+            .id(snapshotId)
+            .projectResource(projectResource)
+            .snapshotSources(List.of(new SnapshotSource().dataset(dataset)));
+
+    // Setup export bucket
+    exportBucket = new GoogleBucketResource().name("test-bucket").projectResource(projectResource);
+  }
+
+  /** Helper method to set up FlightContext mocks with working map and flight ID. */
+  private void setupFlightContext() {
+    when(flightContext.getFlightId()).thenReturn("test-flight-id");
+    FlightMap workingMap = new FlightMap();
+    workingMap.put(SnapshotWorkingMapKeys.SNAPSHOT_EXPORT_BUCKET, exportBucket);
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+  }
+
+  /**
+   * Helper class to hold Storage-related mocks for use in tests. Implements AutoCloseable to allow
+   * use in try-with-resources blocks.
+   */
+  private static class StorageMocks implements AutoCloseable {
+    final MockedStatic<StorageOptions> mockedStorageOptions;
+    final StorageOptions.Builder mockBuilder;
+    final StorageOptions mockStorageOptions;
+    final Storage mockStorage;
+    final WriteChannel mockWriteChannel;
+
+    StorageMocks(
+        MockedStatic<StorageOptions> mockedStorageOptions,
+        StorageOptions.Builder mockBuilder,
+        StorageOptions mockStorageOptions,
+        Storage mockStorage,
+        WriteChannel mockWriteChannel) {
+      this.mockedStorageOptions = mockedStorageOptions;
+      this.mockBuilder = mockBuilder;
+      this.mockStorageOptions = mockStorageOptions;
+      this.mockStorage = mockStorage;
+      this.mockWriteChannel = mockWriteChannel;
+    }
+
+    @Override
+    public void close() {
+      mockedStorageOptions.close();
+    }
+  }
+
+  /**
+   * Helper method to set up Storage client mocks. Returns a StorageMocks object that tests can use
+   * to configure WriteChannel behavior and access all mocks. The MockedStatic is automatically
+   * closed when StorageMocks is closed in a try-with-resources block.
+   */
+  private StorageMocks setupStorageMocks() {
+    MockedStatic<StorageOptions> mockedStorageOptions = mockStatic(StorageOptions.class);
+    StorageOptions.Builder mockBuilder = mock(StorageOptions.Builder.class);
+    StorageOptions mockStorageOptions = mock(StorageOptions.class);
+    Storage mockStorage = mock(Storage.class);
+    WriteChannel mockWriteChannel = mock(WriteChannel.class);
+
+    mockedStorageOptions.when(StorageOptions::newBuilder).thenReturn(mockBuilder);
+    when(mockBuilder.setProjectId(anyString())).thenReturn(mockBuilder);
+    when(mockBuilder.build()).thenReturn(mockStorageOptions);
+    when(mockStorageOptions.getService()).thenReturn(mockStorage);
+    when(mockStorage.writer(any(BlobInfo.class))).thenReturn(mockWriteChannel);
+
+    return new StorageMocks(
+        mockedStorageOptions, mockBuilder, mockStorageOptions, mockStorage, mockWriteChannel);
+  }
+
+  @Test
+  void testDoStep_HandlesStorageCreationFailure() throws Exception {
+    // Test that the step handles failure when creating Storage client
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    setupFlightContext();
+
+    StepResult result = step.doStep(flightContext);
+
+    // Step fails when creating Storage client, returns RETRY
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+    // Verify snapshot is retrieved before the failure
+    verify(snapshotService).retrieve(snapshotId);
+  }
+
+  @Test
+  void testUndoStep() throws Exception {
+    // Setup - undo step doesn't require GCS setup
+    setupFlightContext();
+
+    StepResult result = step.undoStep(flightContext);
+
+    assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+    // Verify deleteFileByName is called - the filename is generated by SnapshotExportUtils
+    // Use any() for bucket since object equality might differ
+    verify(gcsPdao).deleteFileByName(any(GoogleBucketResource.class), anyString());
+  }
+
+  @Test
+  void testDoStep_EmptyCollection() throws Exception {
+    // Test that empty collections create an empty file (success path)
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    setupFlightContext();
+
+    UUID datasetId = snapshot.getSourceDataset().getId();
+    String expectedCollectionName = datasetId.toString() + "-files";
+
+    // Mock StorageOptions and Storage to allow the step to proceed
+    try (StorageMocks storageMocks = setupStorageMocks()) {
+      // Note: write() is not stubbed since no documents are processed for empty collection
+
+      // Mock pagination to process no documents (empty collection)
+      doAnswer(invocation -> null) // No documents processed
+          .when(fireStoreDao)
+          .processCollectionWithPagination(anyString(), anyString(), any());
+
+      StepResult result = step.doStep(flightContext);
+
+      // Verify success - empty file should be created
+      assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+      verify(snapshotService).retrieve(snapshotId);
+      // Verify pagination was called with the correct collection name format
+      verify(fireStoreDao)
+          .processCollectionWithPagination(eq("test-project"), eq(expectedCollectionName), any());
+      // Verify write channel is closed even for empty collection
+      verify(storageMocks.mockWriteChannel).close();
+    }
+  }
+
+  @Test
+  void testDoStep_SuccessWithMockedStorage() throws Exception {
+    // Mock Storage client creation to test the full success path
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    setupFlightContext();
+
+    // Setup mock documents with data - use the actual field names from FireStoreFile
+    Map<String, Object> data1 = new HashMap<>();
+    data1.put(FireStoreFile.FILE_ID_FIELD_NAME, "file-id-1");
+    data1.put(FireStoreFile.GS_PATH_FIELD_NAME, "gs://bucket/file1");
+    when(document1.getData()).thenReturn(data1);
+
+    Map<String, Object> data2 = new HashMap<>();
+    data2.put(FireStoreFile.FILE_ID_FIELD_NAME, "file-id-2");
+    data2.put(FireStoreFile.GS_PATH_FIELD_NAME, "gs://bucket/file2");
+    when(document2.getData()).thenReturn(data2);
+
+    // Mock StorageOptions and Storage
+    try (StorageMocks storageMocks = setupStorageMocks()) {
+      when(storageMocks.mockWriteChannel.write(any(ByteBuffer.class))).thenReturn(1);
+
+      // Mock pagination to process documents
+      doAnswer(
+              invocation -> {
+                bio.terra.service.filedata.google.firestore.InterruptibleConsumer<
+                        QueryDocumentSnapshot>
+                    consumer = invocation.getArgument(2);
+                consumer.accept(document1);
+                consumer.accept(document2);
+                return null;
+              })
+          .when(fireStoreDao)
+          .processCollectionWithPagination(anyString(), anyString(), any());
+
+      StepResult result = step.doStep(flightContext);
+
+      // Verify success
+      assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_SUCCESS));
+      verify(snapshotService).retrieve(snapshotId);
+      verify(fireStoreDao)
+          .processCollectionWithPagination(
+              eq("test-project"),
+              eq(snapshot.getSourceDataset().getId().toString() + "-files"),
+              any(bio.terra.service.filedata.google.firestore.InterruptibleConsumer.class));
+      // Verify documents were written (2 documents = 2 write calls)
+      verify(storageMocks.mockWriteChannel, times(2)).write(any(ByteBuffer.class));
+      verify(storageMocks.mockWriteChannel).close();
+    }
+  }
+
+  @Test
+  void testDoStep_JsonProcessingException() throws Exception {
+    // Test that JsonProcessingException during document serialization returns FATAL
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    setupFlightContext();
+
+    // Setup mock document with data
+    Map<String, Object> data1 = new HashMap<>();
+    data1.put(FireStoreFile.FILE_ID_FIELD_NAME, "file-id-1");
+    data1.put(FireStoreFile.GS_PATH_FIELD_NAME, "gs://bucket/file1");
+    when(document1.getData()).thenReturn(data1);
+
+    // Mock StorageOptions and Storage
+    try (StorageMocks storageMocks = setupStorageMocks()) {
+
+      // Create an ObjectMapper that will throw JsonProcessingException
+      ObjectMapper failingObjectMapper = mock(ObjectMapper.class);
+      JsonProcessingException jsonException = new JsonProcessingException("JSON error") {};
+      when(failingObjectMapper.writeValueAsString(any())).thenThrow(jsonException);
+
+      // Create step with failing ObjectMapper
+      SnapshotExportDumpFirestoreStep failingStep =
+          new SnapshotExportDumpFirestoreStep(
+              snapshotService, fireStoreDao, gcsPdao, snapshotId, failingObjectMapper);
+
+      // Mock pagination to process a document
+      doAnswer(
+              invocation -> {
+                bio.terra.service.filedata.google.firestore.InterruptibleConsumer<
+                        QueryDocumentSnapshot>
+                    consumer = invocation.getArgument(2);
+                consumer.accept(document1);
+                return null;
+              })
+          .when(fireStoreDao)
+          .processCollectionWithPagination(anyString(), anyString(), any());
+
+      StepResult result = failingStep.doStep(flightContext);
+
+      // Verify FATAL error is returned
+      assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_FATAL));
+      assertThat(result.getException().orElse(null), equalTo(jsonException));
+      verify(snapshotService).retrieve(snapshotId);
+    }
+  }
+
+  @Test
+  void testDoStep_IOExceptionDuringWriting() throws Exception {
+    // Test that IOException during document writing returns RETRY
+    // IOException comes from WriteChannel.write(), not ObjectMapper
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    setupFlightContext();
+
+    // Setup mock document with data
+    Map<String, Object> data1 = new HashMap<>();
+    data1.put(FireStoreFile.FILE_ID_FIELD_NAME, "file-id-1");
+    data1.put(FireStoreFile.GS_PATH_FIELD_NAME, "gs://bucket/file1");
+    when(document1.getData()).thenReturn(data1);
+
+    // Mock WriteChannel.write() to throw IOException (this is what GcsChannelWriter.writeLine
+    // calls)
+    IOException ioException = new IOException("IO error");
+    // Mock StorageOptions and Storage
+    try (StorageMocks storageMocks = setupStorageMocks()) {
+      when(storageMocks.mockWriteChannel.write(any(ByteBuffer.class))).thenThrow(ioException);
+
+      // Mock pagination to process a document
+      doAnswer(
+              invocation -> {
+                bio.terra.service.filedata.google.firestore.InterruptibleConsumer<
+                        QueryDocumentSnapshot>
+                    consumer = invocation.getArgument(2);
+                consumer.accept(document1);
+                return null;
+              })
+          .when(fireStoreDao)
+          .processCollectionWithPagination(anyString(), anyString(), any());
+
+      StepResult result = step.doStep(flightContext);
+
+      // Verify RETRY error is returned
+      assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+      assertThat(result.getException().orElse(null), equalTo(ioException));
+      verify(snapshotService).retrieve(snapshotId);
+    }
+  }
+
+  @Test
+  void testDoStep_RuntimeExceptionWithUnknownCause() throws Exception {
+    // Test that RuntimeException with unknown cause (not JsonProcessingException or IOException)
+    // returns RETRY when caught by outer catch block
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    setupFlightContext();
+
+    // Mock StorageOptions and Storage
+    try (StorageMocks storageMocks = setupStorageMocks()) {
+
+      // Mock pagination to throw RuntimeException with unknown cause (not JsonProcessingException
+      // or IOException)
+      RuntimeException runtimeException =
+          new RuntimeException("Unknown error", new IllegalStateException("Some other error"));
+      doThrow(runtimeException)
+          .when(fireStoreDao)
+          .processCollectionWithPagination(anyString(), anyString(), any());
+
+      StepResult result = step.doStep(flightContext);
+
+      // Verify RETRY error is returned (caught by outer catch block at line 90-91)
+      assertThat(result.getStepStatus(), equalTo(StepStatus.STEP_RESULT_FAILURE_RETRY));
+      assertThat(result.getException().orElse(null), equalTo(runtimeException));
+      verify(snapshotService).retrieve(snapshotId);
+    }
+  }
+
+  @Test
+  void testDoStep_SnapshotNotFoundException() throws Exception {
+    // Test that SnapshotNotFoundException from snapshotService.retrieve propagates
+    // (not caught in doStep, so it propagates to Stairway)
+    SnapshotNotFoundException notFoundException =
+        new SnapshotNotFoundException("Snapshot not found: " + snapshotId);
+    when(snapshotService.retrieve(snapshotId)).thenThrow(notFoundException);
+    // Note: flightContext.getFlightId() is not stubbed since exception is thrown before it's called
+
+    // Exception should propagate (not caught in doStep)
+    SnapshotNotFoundException thrown =
+        org.junit.jupiter.api.Assertions.assertThrows(
+            SnapshotNotFoundException.class, () -> step.doStep(flightContext));
+
+    assertThat(thrown, equalTo(notFoundException));
+    verify(snapshotService).retrieve(snapshotId);
+  }
+}


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-312

## Addresses
On export of large snapshots the query was timing out causing the export to fail.
See context here: https://broadinstitute.slack.com/archives/CBJJ7U293/p1767887549964059

## Summary of changes
Add pagination to the document retrieval and processing to prevent timeouts for large snapshots. 

## Testing Strategy
Unit tests
To do: manually test snapshot export with these changes, even if on a small snapshot.

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
