### PR TITLE
DT-400: downgrade Jersey 4.0.1 to 4.0.0

### DIFF
--- a/datarepo-client/build.gradle
+++ b/datarepo-client/build.gradle
@@ -23,7 +23,9 @@ repositories {
 
 dependencies {
     ext {
-        jersey = "4.0.1"
+        // Jersey 4.0.1 looks incompatible with Java 17; see:
+        // https://github.com/eclipse-ee4j/jersey/issues/6064
+        jersey = "4.0.0"
         jackson = "2.21.0"
         swaggerAnnotations = "2.2.42"
         swaggerCli = "3.0.76"


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/DT-400

We are seeing compile failures in the datarepo-client with Jersey 4.0.1. This looks like it is due to `https://github.com/eclipse-ee4j/jersey/issues/6064`. Failures are visible at https://github.com/DataBiosphere/jade-data-repo/actions/workflows/staging-smoke-tests.yaml.

This PR reverts Jersey from 4.0.1 to 4.0.0. Jersey was upgraded in #2066.

I am not (yet) marking Jersey 4.0.1 as unavailable to Dependabot. I am hoping Jersey 4.0.2 is released shortly and we can skip right to that.