### PR TITLE
[DT-3010] Option to require user projects on snapshots

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -512,6 +512,8 @@ public class DrsService {
     CloudPlatformWrapper platform = CloudPlatformWrapper.of(cachedSnapshot.cloudPlatform);
     if (platform.isGcp() && cachedSnapshot.requireUserProject()) {
       if (StringUtils.isEmpty(userProject)) {
+        // Note: This error message is relied upon by DRSHub to determine if it needs to retry the
+        // request with a user project.
         throw new BadRequestException(
             "Snapshot requires an x-user-project header for DRS access URL requests");
       }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -511,13 +511,13 @@ public class DrsService {
 
     CloudPlatformWrapper platform = CloudPlatformWrapper.of(cachedSnapshot.cloudPlatform);
     if (platform.isGcp() && cachedSnapshot.requireUserProject()) {
-      if (StringUtils.isEmpty(userProject)) {
+      if (StringUtils.isBlank(userProject)) {
         // Note: This error message is relied upon by DRSHub to determine if it needs to retry the
         // request with a user project.
         throw new BadRequestException(
             "Snapshot requires an x-user-project header for DRS access URL requests");
       }
-      if (userProject.equals(cachedSnapshot.googleProjectId())) {
+      if (userProject.strip().equalsIgnoreCase(cachedSnapshot.googleProjectId())) {
         throw new BadRequestException(
             "The supplied x-user-project must not be the snapshot's own project");
       }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -12,6 +12,7 @@ import bio.terra.app.usermetrics.BardEventProperties;
 import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.CloudPlatformWrapper;
 import bio.terra.common.FutureUtils;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.exception.UnauthorizedException;
@@ -509,6 +510,16 @@ public class DrsService {
     }
 
     CloudPlatformWrapper platform = CloudPlatformWrapper.of(cachedSnapshot.cloudPlatform);
+    if (platform.isGcp() && cachedSnapshot.requireUserProject()) {
+      if (StringUtils.isEmpty(userProject)) {
+        throw new BadRequestException(
+            "Snapshot requires an x-user-project header for DRS access URL requests");
+      }
+      if (userProject.equals(cachedSnapshot.googleProjectId())) {
+        throw new BadRequestException(
+            "The supplied x-user-project must not be the snapshot's own project");
+      }
+    }
     if (platform.isGcp()) {
       return signGoogleUrl(cachedSnapshot, fsFile.getCloudPath(), authUser, userProject);
     } else if (platform.isAzure()) {
@@ -1044,6 +1055,7 @@ public class DrsService {
       String name,
       boolean isSelfHosted,
       boolean globalFileIds,
+      boolean requireUserProject,
       BillingProfileModel datasetBillingProfileModel,
       UUID snapshotBillingProfileId,
       CloudPlatform cloudPlatform,
@@ -1057,6 +1069,7 @@ public class DrsService {
           snapshot.getName(),
           snapshot.isSelfHosted(),
           snapshot.hasGlobalFileIds(),
+          snapshot.isRequireUserProject(),
           snapshot.getSourceDataset().getDatasetSummary().getDefaultBillingProfile(),
           snapshot.getProfileId(),
           snapshot.getCloudPlatform(),

--- a/src/main/java/bio/terra/service/snapshot/Snapshot.java
+++ b/src/main/java/bio/terra/service/snapshot/Snapshot.java
@@ -42,6 +42,7 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
   private UUID duosFirecloudGroupId;
   private DuosFirecloudGroupModel duosFirecloudGroup;
   private boolean globalFileIds;
+  private boolean requireUserProject;
   private String compactIdPrefix;
   private List<String> tags;
   private ResourceLocks resourceLocks;
@@ -253,6 +254,15 @@ public class Snapshot implements FSContainerInterface, LogPrintable {
 
   public Snapshot globalFileIds(boolean globalFileIds) {
     this.globalFileIds = globalFileIds;
+    return this;
+  }
+
+  public boolean isRequireUserProject() {
+    return requireUserProject;
+  }
+
+  public Snapshot requireUserProject(boolean requireUserProject) {
+    this.requireUserProject = requireUserProject;
     return this;
   }
 

--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -215,11 +215,11 @@ public class SnapshotDao implements TaggableResourceDao {
             INSERT INTO snapshot
             (name, description, profile_id, project_resource_id, id, consent_code, flightid,
               creation_information, properties, global_file_ids, compact_id_prefix,
-              duos_firecloud_group_id, tags)
+              duos_firecloud_group_id, tags, require_user_project)
             VALUES
             (:name, :description, :profile_id, :project_resource_id, :id, :consent_code, :flightid,
               :creation_information::jsonb, :properties::jsonb, :global_file_ids, :compact_id_prefix,
-              :duos_firecloud_group_id, :tags)
+              :duos_firecloud_group_id, :tags, :require_user_project)
             """;
     String creationInfo;
     try {
@@ -249,7 +249,8 @@ public class SnapshotDao implements TaggableResourceDao {
             .addValue("global_file_ids", snapshot.hasGlobalFileIds())
             .addValue("compact_id_prefix", snapshot.getCompactIdPrefix())
             .addValue("duos_firecloud_group_id", snapshot.getDuosFirecloudGroupId())
-            .addValue("tags", tags);
+            .addValue("tags", tags)
+            .addValue("require_user_project", snapshot.isRequireUserProject());
 
     try {
       jdbcTemplate.update(sql, params);
@@ -402,6 +403,7 @@ public class SnapshotDao implements TaggableResourceDao {
                               rs.getString("creation_information")))
                       .consentCode(rs.getString("consent_code"))
                       .globalFileIds(rs.getBoolean("global_file_ids"))
+                      .requireUserProject(rs.getBoolean("require_user_project"))
                       .compactIdPrefix(rs.getString("compact_id_prefix"))
                       .properties(
                           DaoUtils.stringToProperties(objectMapper, rs.getString("properties")))
@@ -660,7 +662,7 @@ public class SnapshotDao implements TaggableResourceDao {
 
     String sql =
         "SELECT snapshot.id, snapshot.name, snapshot.description, snapshot.created_date, snapshot.profile_id, "
-            + "snapshot.global_file_ids, snapshot.tags, snapshot.flightid, "
+            + "snapshot.global_file_ids, snapshot.require_user_project, snapshot.tags, snapshot.flightid, "
             + "snapshot_source.id, "
             + "dataset.secure_monitoring, snapshot.consent_code, dataset.phs_id,"
             + "dataset.self_hosted, dfg.duos_id,"
@@ -715,7 +717,7 @@ public class SnapshotDao implements TaggableResourceDao {
     try {
       String sql =
           "SELECT snapshot.id, snapshot.name, snapshot.description, snapshot.created_date, snapshot.profile_id, "
-              + "snapshot.consent_code, snapshot.global_file_ids, snapshot.tags, snapshot.flightid, "
+              + "snapshot.consent_code, snapshot.global_file_ids, snapshot.require_user_project, snapshot.tags, snapshot.flightid, "
               + "dataset.secure_monitoring, dataset.phs_id, dataset.self_hosted, dfg.duos_id, "
               + summaryCloudPlatformQuery
               + snapshotSourceStorageQuery
@@ -847,6 +849,7 @@ public class SnapshotDao implements TaggableResourceDao {
           .phsId(rs.getString("phs_id"))
           .selfHosted(rs.getBoolean("self_hosted"))
           .globalFileIds(rs.getBoolean("global_file_ids"))
+          .requireUserProject(rs.getBoolean("require_user_project"))
           .tags(DaoUtils.getStringList(rs, "tags"))
           .resourceLocks(new ResourceLocks().exclusive(rs.getString("flightid")))
           .duosId(rs.getString("duos_id"));

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -693,6 +693,7 @@ public class SnapshotService {
         .consentCode(snapshotRequestModel.getConsentCode())
         .properties(snapshotRequestModel.getProperties())
         .globalFileIds(snapshotRequestModel.isGlobalFileIds())
+        .requireUserProject(Boolean.TRUE.equals(snapshotRequestModel.isRequireUserProject()))
         .compactIdPrefix(snapshotRequestModel.getCompactIdPrefix())
         .tags(TagUtils.sanitizeTags(snapshotRequestModel.getTags()));
   }
@@ -1300,6 +1301,7 @@ public class SnapshotService {
             .consentCode(snapshot.getConsentCode())
             .cloudPlatform(snapshot.getCloudPlatform())
             .globalFileIds(snapshot.hasGlobalFileIds())
+            .requireUserProject(snapshot.isRequireUserProject())
             .compactIdPrefix(snapshot.getCompactIdPrefix())
             .tags(snapshot.getTags())
             .resourceLocks(snapshot.getResourceLocks());

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -26,6 +26,7 @@ public class SnapshotSummary {
   private String phsId;
   private boolean selfHosted;
   private boolean globalFileIds;
+  private boolean requireUserProject;
   private List<String> tags;
   private ResourceLocks resourceLocks;
   private String duosId;
@@ -156,6 +157,15 @@ public class SnapshotSummary {
     return this;
   }
 
+  public boolean isRequireUserProject() {
+    return requireUserProject;
+  }
+
+  public SnapshotSummary requireUserProject(boolean requireUserProject) {
+    this.requireUserProject = requireUserProject;
+    return this;
+  }
+
   public List<String> getTags() {
     return tags;
   }
@@ -199,6 +209,7 @@ public class SnapshotSummary {
         .phsId(getPhsId())
         .selfHosted(isSelfHosted())
         .globalFileIds(isGlobalFileIds())
+        .requireUserProject(isRequireUserProject())
         .tags(getTags())
         .resourceLocks(getResourceLocks())
         .duosId(getDuosId());

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6731,6 +6731,13 @@ components:
           description: >
             if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
             if true, drs ids will be in the format: v2_<fileid>
+        requireUserProject:
+          type: boolean
+          default: false
+          description: >
+            If true, callers must supply an x-user-project header that differs from the
+            snapshot's own Google project when requesting a signed DRS access URL. This
+            prevents the snapshot's billing project from being charged for egress.
         compactIdPrefix:
           $ref: '#/components/schemas/CompactIdPrefix'
         tags:
@@ -6909,6 +6916,13 @@ components:
           description: >
             if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
             if true, drs ids will be in the format: v2_<fileid>
+        requireUserProject:
+          type: boolean
+          default: false
+          description: >
+            If true, callers must supply an x-user-project header that differs from the
+            snapshot's own Google project when requesting a signed DRS access URL. This
+            prevents the snapshot's billing project from being charged for egress.
         tags:
           type: array
           items:
@@ -7028,6 +7042,13 @@ components:
           description: >
             if false, the drs ids will be in the format: v1_<snapshotid>_<fileid>
             if true, drs ids will be in the format: v2_<fileid>
+        requireUserProject:
+          type: boolean
+          default: false
+          description: >
+            If true, callers must supply an x-user-project header that differs from the
+            snapshot's own Google project when requesting a signed DRS access URL. This
+            prevents the snapshot's billing project from being charged for egress.
         compactIdPrefix:
           $ref: '#/components/schemas/CompactIdPrefix'
         tags:

--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -93,4 +93,5 @@
     <include file="changesets/20241127_asset_column_asset_id_index.yaml" relativeToChangelogFile="true" />
     <include file="changesets/20250218_dataset_inherit_steward_flag.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20251008_add_indexes_getaccessiblesnapshots.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20260310_snapshot_require_user_project.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20260310_snapshot_require_user_project.yaml
+++ b/src/main/resources/db/changesets/20260310_snapshot_require_user_project.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshot_require_user_project
+      author: fboulnoi
+      changes:
+        - addColumn:
+            tableName: snapshot
+            columns:
+              name: require_user_project
+              type: boolean
+              defaultValue: false
+              constraints:
+                nullable: false

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -36,6 +36,7 @@ import bio.terra.app.usermetrics.UserLoggingMetrics;
 import bio.terra.common.TestUtils;
 import bio.terra.common.UriUtils;
 import bio.terra.common.category.Unit;
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.externalcreds.model.ValidatePassportResult;
@@ -858,6 +859,85 @@ class DrsServiceTest {
         "contains requester email",
         UriUtils.getValueFromQueryParameter(url.getUrl(), GcsConstants.REQUESTED_BY_QUERY_PARAM),
         equalTo(TEST_USER.getEmail()));
+  }
+
+  @Test
+  void getAccessUrlRequiresUserProjectWhenFlagSet() {
+    Snapshot snapshot =
+        mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
+    snapshot.requireUserProject(true);
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+
+    DRSObject drsObject = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            drsService.getAccessUrlForObjectId(
+                TEST_USER,
+                googleDrsObjectId,
+                drsObject.getAccessMethods().get(0).getAccessId(),
+                null));
+  }
+
+  @Test
+  void getAccessUrlRejectsSnapshotProjectWhenFlagSet() {
+    Snapshot snapshot =
+        mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
+    snapshot.requireUserProject(true);
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+
+    DRSObject drsObject = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            drsService.getAccessUrlForObjectId(
+                TEST_USER,
+                googleDrsObjectId,
+                drsObject.getAccessMethods().get(0).getAccessId(),
+                SNAPSHOT_DATA_PROJECT));
+  }
+
+  @Test
+  void getAccessUrlSucceedsWithDifferentUserProject() {
+    Snapshot snapshot =
+        mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
+    snapshot.requireUserProject(true);
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    when(snapshotService.retrieveSnapshotSummary(snapshotId))
+        .thenReturn(new SnapshotSummaryModel().id(snapshotId));
+
+    String differentProject = "my-other-project";
+    Storage storage = mock(Storage.class);
+    when(drsService.initStorage(SNAPSHOT_DATA_PROJECT)).thenReturn(storage);
+    when(storage.signUrl(any(), any(long.class), any(), any(), any()))
+        .thenAnswer(a -> new java.net.URL("https://storage.googleapis.com/path/to/file.txt"));
+
+    DRSObject drsObject = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    DRSAccessURL result =
+        drsService.getAccessUrlForObjectId(
+            TEST_USER,
+            googleDrsObjectId,
+            drsObject.getAccessMethods().get(0).getAccessId(),
+            differentProject);
+    assertThat("returns a URL", result.getUrl(), containsString("storage.googleapis.com"));
+  }
+
+  @Test
+  void getAccessUrlWithoutRequireUserProjectFlagSucceedsWithoutUserProject() {
+    // Default snapshot has requireUserProject = false; no userProject supplied → should pass
+    DRSObject drsObject = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    when(snapshotService.retrieveSnapshotSummary(snapshotId))
+        .thenReturn(new SnapshotSummaryModel().id(snapshotId));
+
+    Storage storage = mock(Storage.class);
+    when(drsService.initStorage(SNAPSHOT_DATA_PROJECT)).thenReturn(storage);
+    when(storage.signUrl(any(), any(long.class), any(), any(), any()))
+        .thenAnswer(a -> new java.net.URL("https://storage.googleapis.com/path/to/file.txt"));
+
+    DRSAccessURL result =
+        drsService.getAccessUrlForObjectId(
+            TEST_USER, googleDrsObjectId, drsObject.getAccessMethods().get(0).getAccessId(), null);
+    assertThat("returns a URL", result.getUrl(), containsString("storage.googleapis.com"));
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -880,7 +880,7 @@ class DrsServiceTest {
   }
 
   @Test
-  void getAccessUrlRejectsSnapshotProjectWhenFlagSet() {
+  void getAccessUrlRejectsBlankUserProjectWhenFlagSet() {
     Snapshot snapshot =
         mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
     snapshot.requireUserProject(true);
@@ -894,7 +894,39 @@ class DrsServiceTest {
                 TEST_USER,
                 googleDrsObjectId,
                 drsObject.getAccessMethods().get(0).getAccessId(),
-                SNAPSHOT_DATA_PROJECT));
+                "   "));
+  }
+
+  @Test
+  void getAccessUrlRejectsSnapshotProjectWhenFlagSet() {
+    Snapshot snapshot =
+        mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
+    snapshot.requireUserProject(true);
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+
+    DRSObject drsObject = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    String accessId = drsObject.getAccessMethods().get(0).getAccessId();
+
+    // exact match
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            drsService.getAccessUrlForObjectId(
+                TEST_USER, googleDrsObjectId, accessId, SNAPSHOT_DATA_PROJECT));
+
+    // mixed-case bypass attempt
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            drsService.getAccessUrlForObjectId(
+                TEST_USER, googleDrsObjectId, accessId, SNAPSHOT_DATA_PROJECT.toUpperCase()));
+
+    // whitespace-padded bypass attempt
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            drsService.getAccessUrlForObjectId(
+                TEST_USER, googleDrsObjectId, accessId, "  " + SNAPSHOT_DATA_PROJECT + "  "));
   }
 
   @Test


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-3010

## Summary of changes

Adds a `requireUserProject` boolean to snapshot creation which requires the user to always pass a user project for DRS resolution following the implementation approach outlined in the ticket. The value is `false` by default so no migration of existing snapshots is required. Updating a snapshot to contain the flag will be done in a separate ticket.

## Testing Strategy

Added unit tests for each condition:

1. Flag is set, no flag passed in -> error
2. Flag is set, project is same as snapshot -> error
3. Flag is set, different user project -> ok
4. Flag not explicitly set, no user project -> ok

The connected and integration test failures are known issues with TDR: https://github.com/DataBiosphere/jade-data-repo/pull/2076