### PR TITLE
PROD-1042: Bump TCL Version to upgrade K8 client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,7 +204,7 @@ dependencies {
     implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:7.6.0'
     implementation 'net.javacrumbs.shedlock:shedlock-spring:7.6.0'
 
-    implementation 'bio.terra:terra-common-lib:1.1.69-SNAPSHOT'
+    implementation 'bio.terra:terra-common-lib:1.1.70-SNAPSHOT'
     implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.415'
     implementation 'bio.terra:terra-policy-client:1.0.43-SNAPSHOT'
     implementation 'bio.terra:terra-resource-buffer-client:0.198.153-SNAPSHOT'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/PROD-1042

## Addresses
TDR prod is down due to a conflict in the Kubernetes client version. 

## Summary of changes
- Bump TCL version 

## Testing Strategy


<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
