### PR TITLE
[DT-3020] Allow `requireUserProject` flag to be updated

### DIFF
--- a/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotDao.java
@@ -770,13 +770,16 @@ public class SnapshotDao implements TaggableResourceDao {
     String sql =
         "UPDATE snapshot SET consent_code = COALESCE(:consent_code, consent_code), "
             + "description = COALESCE(:description, description), "
-            + "properties = COALESCE(:properties::jsonb, properties) WHERE id = :id";
+            + "properties = COALESCE(:properties::jsonb, properties), "
+            + "require_user_project = COALESCE(:require_user_project, require_user_project) "
+            + "WHERE id = :id";
 
     MapSqlParameterSource params =
         new MapSqlParameterSource()
             .addValue("consent_code", patchRequest.getConsentCode())
             .addValue("description", patchRequest.getDescription())
             .addValue("id", id)
+            .addValue("require_user_project", patchRequest.isRequireUserProject())
             .addValue(
                 "properties",
                 DaoUtils.propertiesToString(objectMapper, patchRequest.getProperties()));

--- a/src/main/resources/api/data-repository-openapi.yaml
+++ b/src/main/resources/api/data-repository-openapi.yaml
@@ -6855,6 +6855,12 @@ components:
         properties:
           type: object
           description: Additional JSON metadata about the snapshot (this does not need to adhere to a particular schema)
+        requireUserProject:
+          type: boolean
+          description: >
+            If true, callers must supply an x-user-project header differing from the
+            snapshot's own project when requesting a DRS access URL. Setting this to
+            false disables the requirement. Null leaves the current value unchanged.
       description: >
         A 'lite' snapshot definition (used to modify supported fields of a snapshot).
         Null assignments will be ignored.

--- a/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotDaoTest.java
@@ -826,6 +826,41 @@ class SnapshotDaoTest {
   }
 
   @Test
+  void patchSnapshotRequireUserProject() {
+    snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
+    Snapshot created = createSnapshot(snapshotRequest);
+    UUID snapshotId = created.getId();
+
+    assertThat(
+        "snapshot requireUserProject defaults to false before any patch",
+        snapshotDao.retrieveSnapshot(snapshotId).isRequireUserProject(),
+        equalTo(false));
+
+    // Enable the flag
+    snapshotDao.patch(
+        snapshotId, new SnapshotPatchRequestModel().requireUserProject(true), TEST_USER);
+    assertThat(
+        "snapshot requireUserProject is set to true after patch",
+        snapshotDao.retrieveSnapshot(snapshotId).isRequireUserProject(),
+        equalTo(true));
+
+    // Null in patch leaves value unchanged
+    snapshotDao.patch(snapshotId, new SnapshotPatchRequestModel(), TEST_USER);
+    assertThat(
+        "snapshot requireUserProject is unchanged when not specified in patch",
+        snapshotDao.retrieveSnapshot(snapshotId).isRequireUserProject(),
+        equalTo(true));
+
+    // Explicitly set back to false
+    snapshotDao.patch(
+        snapshotId, new SnapshotPatchRequestModel().requireUserProject(false), TEST_USER);
+    assertThat(
+        "snapshot requireUserProject is set back to false after patch",
+        snapshotDao.retrieveSnapshot(snapshotId).isRequireUserProject(),
+        equalTo(false));
+  }
+
+  @Test
   void getAccessibleSnapshots() {
     snapshotRequest.name(snapshotRequest.getName() + UUID.randomUUID());
     UUID snapshotId = createSnapshot(snapshotRequest).getId();

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -470,6 +470,11 @@ class SnapshotServiceTest {
         service.patchSnapshotIamActions(
             new SnapshotPatchRequestModel().description("a description")),
         containsInAnyOrder(IamAction.UPDATE_SNAPSHOT));
+
+    assertThat(
+        "Patch with requireUserProject update requires only UPDATE_SNAPSHOT",
+        service.patchSnapshotIamActions(new SnapshotPatchRequestModel().requireUserProject(true)),
+        containsInAnyOrder(IamAction.UPDATE_SNAPSHOT));
   }
 
   @Test


### PR DESCRIPTION
## Addresses

https://broadworkbench.atlassian.net/browse/DT-3020

## Summary of changes

Allows the `requireUserProject` flag introduced in #2081 to be updated on existing snapshots.

## Testing Strategy

Unit tests.