### PR TITLE
CTM-460: Enforce max_bad_records validation for GCP ingests

### DIFF
--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStep.java
@@ -11,6 +11,7 @@ import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
 import java.util.List;
 
 public class IngestLoadTableStep implements Step {
@@ -47,13 +48,14 @@ public class IngestLoadTableStep implements Step {
     long badRecords = ingestStatistics.getBadRecords();
     Integer maxBadRecords = ingestRequest.getMaxBadRecords();
     if (maxBadRecords != null && badRecords > maxBadRecords) {
-      throw new IngestFailureException(
-          String.format("Failed to load data into dataset %s", dataset.getId()),
-          List.of(
-              String.format(
-                  "%d records failed to ingest, which is equal to or more than the %d allowed failed records",
-                  badRecords, maxBadRecords),
-              "Check that all records have data for columns marked as required in the dataset schema."));
+      return new StepResult(
+          StepStatus.STEP_RESULT_FAILURE_FATAL,
+          new IngestFailureException(
+              String.format("Failed to load data into dataset %s", dataset.getId()),
+              List.of(
+                  String.format(
+                      "%d records failed to ingest, which is equal to or more than the %d allowed failed records",
+                      badRecords, maxBadRecords))));
     }
 
     return StepResult.getStepResultSuccess();

--- a/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStep.java
+++ b/src/main/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStep.java
@@ -5,11 +5,13 @@ import bio.terra.model.IngestRequestModel;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetService;
 import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.exception.IngestFailureException;
 import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
 import bio.terra.stairway.FlightContext;
 import bio.terra.stairway.FlightMap;
 import bio.terra.stairway.Step;
 import bio.terra.stairway.StepResult;
+import java.util.List;
 
 public class IngestLoadTableStep implements Step {
   private final DatasetService datasetService;
@@ -39,6 +41,20 @@ public class IngestLoadTableStep implements Step {
     // Save away the stats in the working map. We will use some of them later
     // when we make the annotations. Others are returned on the ingest response.
     IngestUtils.putIngestStatistics(context, ingestStatistics);
+
+    // Validate that bad records don't exceed the threshold
+    // This matches the validation performed for Azure ingests in IngestValidateScratchTableStep
+    long badRecords = ingestStatistics.getBadRecords();
+    Integer maxBadRecords = ingestRequest.getMaxBadRecords();
+    if (maxBadRecords != null && badRecords > maxBadRecords) {
+      throw new IngestFailureException(
+          String.format("Failed to load data into dataset %s", dataset.getId()),
+          List.of(
+              String.format(
+                  "%d records failed to ingest, which is equal to or more than the %d allowed failed records",
+                  badRecords, maxBadRecords),
+              "Check that all records have data for columns marked as required in the dataset schema."));
+    }
 
     return StepResult.getStepResultSuccess();
   }

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStepTest.java
@@ -146,17 +146,11 @@ class IngestLoadTableStepTest {
     mockedUtils.verify(() -> IngestUtils.putIngestStatistics(flightContext, stats));
   }
 
-  @ParameterizedTest
-  @CsvSource({
-    "0, 1", // maxBadRecords=0, badRecords=1 - should fail
-    "0, 5", // maxBadRecords=0, badRecords=5 - should fail (user-reported case)
-    "5, 6", // maxBadRecords=5, badRecords=6 - should fail
-    "10, 11", // maxBadRecords=10, badRecords=11 - should fail
-    "100, 101" // maxBadRecords=100, badRecords=101 - should fail
-  })
-  void testDoStep_failure_exceedsMaxBadRecords(int maxBadRecords, int badRecords)
-      throws InterruptedException {
+  @Test
+  void testDoStep_failure_exceedsMaxBadRecords() throws InterruptedException {
     // Arrange
+    int maxBadRecords = 0;
+    int badRecords = 1;
     setupDoStepMocks();
     ingestRequest.maxBadRecords(maxBadRecords);
     PdaoLoadStatistics stats =

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStepTest.java
@@ -1,0 +1,286 @@
+package bio.terra.service.dataset.flight.ingest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.common.PdaoLoadStatistics;
+import bio.terra.common.category.Unit;
+import bio.terra.model.IngestRequestModel;
+import bio.terra.service.dataset.Dataset;
+import bio.terra.service.dataset.DatasetService;
+import bio.terra.service.dataset.DatasetTable;
+import bio.terra.service.dataset.exception.IngestFailureException;
+import bio.terra.service.tabulardata.google.bigquery.BigQueryDatasetPdao;
+import bio.terra.stairway.FlightContext;
+import bio.terra.stairway.FlightMap;
+import bio.terra.stairway.StepResult;
+import bio.terra.stairway.StepStatus;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@Tag(Unit.TAG)
+class IngestLoadTableStepTest {
+
+  @Mock private DatasetService datasetService;
+  @Mock private BigQueryDatasetPdao bigQueryDatasetPdao;
+  @Mock private FlightContext flightContext;
+  @Mock private FlightMap workingMap;
+
+  private MockedStatic<IngestUtils> mockedUtils;
+  private IngestLoadTableStep step;
+
+  private Dataset dataset;
+  private DatasetTable datasetTable;
+  private IngestRequestModel ingestRequest;
+
+  @BeforeEach
+  void setUp() {
+    mockedUtils = mockStatic(IngestUtils.class);
+    step = new IngestLoadTableStep(datasetService, bigQueryDatasetPdao);
+
+    // Setup common test data
+    dataset = new Dataset();
+    dataset.id(UUID.randomUUID());
+    dataset.name("test_dataset");
+
+    datasetTable = new DatasetTable();
+    datasetTable.name("test_table");
+
+    ingestRequest = new IngestRequestModel();
+    ingestRequest.table("test_table");
+    ingestRequest.format(IngestRequestModel.FormatEnum.JSON);
+  }
+
+  private void setupDoStepMocks() {
+    // Setup mocks needed for doStep tests
+    when(flightContext.getWorkingMap()).thenReturn(workingMap);
+    when(IngestUtils.getDataset(flightContext, datasetService)).thenReturn(dataset);
+    when(IngestUtils.getDatasetTable(flightContext, dataset)).thenReturn(datasetTable);
+    when(IngestUtils.getStagingTableName(flightContext)).thenReturn("staging_table");
+    when(IngestUtils.getIngestRequestModel(flightContext)).thenReturn(ingestRequest);
+    when(workingMap.get(eq(IngestMapKeys.INGEST_CONTROL_FILE_PATH), eq(String.class)))
+        .thenReturn("gs://test-bucket/test-file.json");
+  }
+
+  private void setupUndoStepMocks() {
+    // Setup mocks needed for undoStep tests
+    when(IngestUtils.getDataset(flightContext, datasetService)).thenReturn(dataset);
+    when(IngestUtils.getStagingTableName(flightContext)).thenReturn("staging_table");
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockedUtils.close();
+  }
+
+  @Test
+  void testDoStep_success_noBadRecords() throws InterruptedException {
+    // Arrange
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(0);
+    PdaoLoadStatistics stats = new PdaoLoadStatistics(0, 100, Instant.now(), Instant.now());
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    StepResult result = step.doStep(flightContext);
+
+    // Assert
+    assertTrue(result.isSuccess());
+    mockedUtils.verify(() -> IngestUtils.putIngestStatistics(flightContext, stats));
+  }
+
+  @Test
+  void testDoStep_success_withinBadRecordsThreshold() throws InterruptedException {
+    // Arrange
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(10);
+    PdaoLoadStatistics stats = new PdaoLoadStatistics(5, 100, Instant.now(), Instant.now());
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    StepResult result = step.doStep(flightContext);
+
+    // Assert
+    assertTrue(result.isSuccess());
+    mockedUtils.verify(() -> IngestUtils.putIngestStatistics(flightContext, stats));
+  }
+
+  @Test
+  void testDoStep_success_nullMaxBadRecords() throws InterruptedException {
+    // Arrange - maxBadRecords is null (no limit)
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(null);
+    PdaoLoadStatistics stats = new PdaoLoadStatistics(100, 100, Instant.now(), Instant.now());
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    StepResult result = step.doStep(flightContext);
+
+    // Assert - should succeed even with many bad records when maxBadRecords is null
+    assertTrue(result.isSuccess());
+    mockedUtils.verify(() -> IngestUtils.putIngestStatistics(flightContext, stats));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "0, 1", // maxBadRecords=0, badRecords=1 - should fail
+    "0, 5", // maxBadRecords=0, badRecords=5 - should fail (user-reported case)
+    "5, 6", // maxBadRecords=5, badRecords=6 - should fail
+    "10, 11", // maxBadRecords=10, badRecords=11 - should fail
+    "100, 101" // maxBadRecords=100, badRecords=101 - should fail
+  })
+  void testDoStep_failure_exceedsMaxBadRecords(int maxBadRecords, int badRecords)
+      throws InterruptedException {
+    // Arrange
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(maxBadRecords);
+    PdaoLoadStatistics stats =
+        new PdaoLoadStatistics(badRecords, 100, Instant.now(), Instant.now());
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    StepResult result = step.doStep(flightContext);
+
+    // Assert - should return failure result
+    assertEquals(
+        StepStatus.STEP_RESULT_FAILURE_FATAL,
+        result.getStepStatus(),
+        "Step should fail when bad records exceed threshold");
+    assertTrue(result.getException().isPresent(), "Result should contain exception");
+
+    IngestFailureException exception = (IngestFailureException) result.getException().get();
+    String expectedMessage = String.format("Failed to load data into dataset %s", dataset.getId());
+    assertEquals(expectedMessage, exception.getMessage());
+
+    // Verify error details
+    assertTrue(exception.getCauses().size() >= 1);
+    String errorDetail = exception.getCauses().get(0);
+    assertTrue(
+        errorDetail.contains(String.format("%d records failed to ingest", badRecords)),
+        "Error should mention bad record count");
+    assertTrue(
+        errorDetail.contains(String.format("%d allowed failed records", maxBadRecords)),
+        "Error should mention max allowed");
+
+    // Verify statistics were still saved before failure
+    mockedUtils.verify(() -> IngestUtils.putIngestStatistics(flightContext, stats));
+  }
+
+  @Test
+  void testDoStep_failure_maxBadRecordsZero_withBadRecords() throws InterruptedException {
+    // Arrange - This is the specific case reported by users
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(0);
+    PdaoLoadStatistics stats = new PdaoLoadStatistics(5, 5, Instant.now(), Instant.now());
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    StepResult result = step.doStep(flightContext);
+
+    // Assert - should return failure result
+    assertEquals(
+        StepStatus.STEP_RESULT_FAILURE_FATAL,
+        result.getStepStatus(),
+        "Step should fail when bad records exceed threshold");
+    assertTrue(result.getException().isPresent(), "Result should contain exception");
+
+    IngestFailureException exception = (IngestFailureException) result.getException().get();
+    assertTrue(exception.getMessage().contains("Failed to load data into dataset"));
+    assertTrue(
+        exception.getCauses().get(0).contains("5 records failed to ingest"),
+        "Should mention 5 failed records");
+    assertTrue(
+        exception.getCauses().get(0).contains("0 allowed failed records"),
+        "Should mention 0 allowed");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "5, 5", // Exactly at threshold - should succeed
+    "10, 10", // Exactly at threshold - should succeed
+    "0, 0" // No bad records with zero tolerance - should succeed
+  })
+  void testDoStep_success_exactlyAtThreshold(int maxBadRecords, int badRecords)
+      throws InterruptedException {
+    // Arrange
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(maxBadRecords);
+    PdaoLoadStatistics stats =
+        new PdaoLoadStatistics(badRecords, 100, Instant.now(), Instant.now());
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    StepResult result = step.doStep(flightContext);
+
+    // Assert - should succeed when badRecords equals maxBadRecords
+    assertTrue(result.isSuccess());
+    mockedUtils.verify(() -> IngestUtils.putIngestStatistics(flightContext, stats));
+  }
+
+  @Test
+  void testUndoStep_deleteStagingTable() throws InterruptedException {
+    // Arrange
+    setupUndoStepMocks();
+
+    // Act
+    StepResult result = step.undoStep(flightContext);
+
+    // Assert
+    assertTrue(result.isSuccess());
+    verify(bigQueryDatasetPdao).deleteDatasetTable(dataset, "staging_table");
+  }
+
+  @Test
+  void testDoStep_verifiesLoadToStagingTableCalledWithCorrectParams() throws InterruptedException {
+    // Arrange
+    setupDoStepMocks();
+    ingestRequest.maxBadRecords(0);
+    PdaoLoadStatistics stats = new PdaoLoadStatistics(0, 100, Instant.now(), Instant.now());
+    String controlFilePath = "gs://test-bucket/test-file.json";
+
+    when(bigQueryDatasetPdao.loadToStagingTable(
+            eq(dataset), eq(datasetTable), eq("staging_table"), eq(ingestRequest), anyString()))
+        .thenReturn(stats);
+
+    // Act
+    step.doStep(flightContext);
+
+    // Assert - verify the PDAO was called with correct parameters
+    verify(bigQueryDatasetPdao)
+        .loadToStagingTable(dataset, datasetTable, "staging_table", ingestRequest, controlFilePath);
+  }
+}

--- a/src/test/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStepTest.java
+++ b/src/test/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStepTest.java
@@ -74,7 +74,7 @@ class IngestLoadTableStepTest {
     when(IngestUtils.getDatasetTable(flightContext, dataset)).thenReturn(datasetTable);
     when(IngestUtils.getStagingTableName(flightContext)).thenReturn("staging_table");
     when(IngestUtils.getIngestRequestModel(flightContext)).thenReturn(ingestRequest);
-    when(workingMap.get(eq(IngestMapKeys.INGEST_CONTROL_FILE_PATH), eq(String.class)))
+    when(workingMap.get(IngestMapKeys.INGEST_CONTROL_FILE_PATH, String.class))
         .thenReturn("gs://test-bucket/test-file.json");
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-460

## Summary
Adds validation to GCP ingests to enforce the `max_bad_records` threshold, matching existing Azure behavior. It seems that there is a bug where GCP ingests would succeed even when `bad_row_count > max_bad_records`.

## Problem
During the April 2026 production outage investigation, users reported that ingests with `"max_bad_records": 0, "max_failed_file_loads": 0` returned `"job_status": "succeeded"` despite having `"bad_row_count": 5`.

**Example user report:**
**Job Status**
```json
{
  "id": "TZY7pJVWRUe9yQZEacOh7w",
  "description": "<redacted>",
  "job_status": "succeeded",
  "status_code": 200,
  "submitted": "2026-04-13T16:01:56.851030Z",
  "completed": "2026-04-13T16:52:53.702082Z",
  "class_name": "bio.terra.service.dataset.flight.ingest.DatasetIngestFlight",
  "target_iam_resource": {
    "type": "dataset",
    "id": "<redacted>",
    "action": "ingest_data"
  }
}
```
**Job Result** 
```json
{
  "dataset_id": "<redacted>",
  "dataset":"<redacted>",
  "table": "<redacted>",
  "path": null,
  "load_tag": "load-at-2026-04-13T16:01:40.080100044Z",
  "row_count": 5,
  "bad_row_count": 5,
  "load_result": {
    "loadSummary": {
      "loadTag": "load-at-2026-04-13T16:01:40.080100044Z",
      "jobId": "TZY7pJVWRUe9yQZEacOh7w",
      "totalFiles": 0,
      "succeededFiles": 0,
      "failedFiles": 0,
      "notTriedFiles": 0
    },
    "loadFileResults": []
  }
}
```

**Expected behavior:** The ingest should fail when `bad_row_count > max_bad_records`.

## Root Cause
- **Azure ingests:** Already validate `failCount > maxBadRecords` in `IngestValidateScratchTableStep.java:45-53`
- **GCP ingests:** Missing this validation in `IngestLoadTableStep.java`

When BigQuery loads data with `setMaxBadRecords(0)`:
1. BigQuery rejects rows that fail schema validation
2. Load job returns statistics with `badRecords > 0`
3. TDR stores these statistics but never validates against the threshold
4. Flight completes successfully with `bad_row_count > 0`

## Changes
- **File:** `src/main/java/bio/terra/service/dataset/flight/ingest/IngestLoadTableStep.java`
- **Added:** Validation that `badRecords <= maxBadRecords` after BigQuery load completes
- **Behavior:** Throws `IngestFailureException` when threshold is exceeded, matching Azure behavior

```java
long badRecords = ingestStatistics.getBadRecords();
Integer maxBadRecords = ingestRequest.getMaxBadRecords();
if (maxBadRecords != null && badRecords > maxBadRecords) {
  throw new IngestFailureException(
      String.format("Failed to load data into dataset %s", dataset.getId()),
      List.of(
          String.format(
              "%d records failed to ingest, which is equal to or more than the %d allowed failed records",
              badRecords, maxBadRecords),
          "Check that all records have data for columns marked as required in the dataset schema."));
}
```

## Testing
- Unit tests
- Manual testing: I tried to reproduce this situation locally and haven't figured it out yet. My current thought is that this was a situation brought on by the high DB load and that it shouldn't happen in real situations. But, I don't think it should hurt to do this check. 

## Impact
- **Breaking change:** Users who set `max_bad_records: 0` expecting lenient behavior will now see their ingests fail
- **Expected impact:** Low - users setting `max_bad_records: 0` likely expect strict validation