### PR TITLE
[CTM-470] Temporarily disable `UserMetricsInterceptor`

### DIFF
--- a/src/main/java/bio/terra/app/configuration/WebConfig.java
+++ b/src/main/java/bio/terra/app/configuration/WebConfig.java
@@ -27,7 +27,8 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
     registry.addInterceptor(loggerInterceptor);
-    registry.addInterceptor(metricsInterceptor);
+    // Temporarily disabled due to thread pool exhaustion under high load
+    // registry.addInterceptor(metricsInterceptor);
   }
 
   @Override


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-470

## Addresses

Production thread pool exhaustion causing thousands of error logs under high API traffic load.

## Summary of Changes

Temporarily disables the `UserMetricsInterceptor` that logs API requests to Bard. Under high load (30+ requests/second), the metrics thread pool (100 threads, 100 queue) becomes saturated, causing `RejectedExecutionException` errors for every request that cannot submit a metrics task.

**Changes:**
- Comment out `metricsInterceptor` registration in `WebConfig.java`
- Request/response logging (`loggerInterceptor`) remains active

## Problem Details

**Symptoms:**
- 1,600+ errors per 30 minutes in production logs
- 80% of production errors are `RejectedExecutionException` from metrics logging
- Thread pool: `[Running, pool size = 100, active threads = 100, queued tasks = 100]`

**Example Error:**
```
HandlerInterceptor.afterCompletion threw exception
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@2c9ce218[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@309e5bf8[Wrapped task = bio.terra.app.usermetrics.UserMetricsInterceptor$$Lambda$2726/0x000079e3a508a328@39f9f5bc]] rejected from java.util.concurrent.ThreadPoolExecutor@483f19c0[Running, pool size = 100, active threads = 100, queued tasks = 100, completed tasks = 442]
	at java.base/java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.reject(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.execute(Unknown Source)
	at java.base/java.util.concurrent.AbstractExecutorService.submit(Unknown Source)
	at bio.terra.app.usermetrics.UserMetricsInterceptor.afterCompletion(UserMetricsInterceptor.java:73)
```

**Root Cause:**
- `UserMetricsInterceptor.afterCompletion()` submits an async task to log metrics for **every** API request
- Thread pool configured with 100 threads + 100 queue capacity (200 total)
- At sustained 30+ req/sec, pool saturates in ~6 seconds
- After saturation, all new metrics tasks are rejected with `AbortPolicy`
- Rejections are logged as ERROR even though the actual API request succeeded

**Impact:**
- Makes monitoring difficult (thousands of non-critical errors obscure real issues)
- No impact on API functionality (errors occur in `afterCompletion`, after response sent)
- Metrics are lost but API requests succeed

## Testing Strategy

- [x] Verify application starts without errors
- [ ] Monitor production after deployment

## Future Work

Options to re-enable metrics:
1. Increase thread pool size significantly (500-1000 threads)
2. Change rejection policy from `AbortPolicy` to `CallerRunsPolicy` or `DiscardOldestPolicy`
3. Add batching to reduce per-request overhead
4. Add configuration flag to enable/disable metrics at runtime