### PR TITLE
Fix UnauthorizedException handling in DRS API controller

### DIFF
--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -3,6 +3,7 @@ package bio.terra.app.controller;
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.app.controller.exception.TooManyRequestsException;
 import bio.terra.common.exception.BadRequestException;
+import bio.terra.common.exception.ErrorReportException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.NotImplementedException;
 import bio.terra.common.exception.UnauthorizedException;
@@ -111,6 +112,12 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
     DRSError error =
         new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.UNAUTHORIZED.value());
     return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler
+  public ResponseEntity<DRSError> forbiddenHandler(ErrorReportException ex) {
+    DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.FORBIDDEN.value());
+    return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -5,6 +5,7 @@ import bio.terra.app.controller.exception.TooManyRequestsException;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.exception.NotImplementedException;
+import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.controller.DataRepositoryServiceApi;
@@ -100,6 +101,13 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
 
   @ExceptionHandler
   public ResponseEntity<DRSError> iAmUnauthorizedExceptionHandler(IamUnauthorizedException ex) {
+    DRSError error =
+        new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.UNAUTHORIZED.value());
+    return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);
+  }
+
+  @ExceptionHandler
+  public ResponseEntity<DRSError> unauthorizedExceptionHandler(UnauthorizedException ex) {
     DRSError error =
         new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.UNAUTHORIZED.value());
     return new ResponseEntity<>(error, HttpStatus.UNAUTHORIZED);

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -115,9 +115,10 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   @ExceptionHandler
-  public ResponseEntity<DRSError> forbiddenHandler(ErrorReportException ex) {
-    DRSError error = new DRSError().msg(ex.getMessage()).statusCode(HttpStatus.FORBIDDEN.value());
-    return new ResponseEntity<>(error, HttpStatus.FORBIDDEN);
+  public ResponseEntity<DRSError> errorReportExceptionHandler(ErrorReportException ex) {
+    HttpStatus exceptionStatus = ex.getStatusCode();
+    DRSError error = new DRSError().msg(ex.getMessage()).statusCode(exceptionStatus.value());
+    return new ResponseEntity<>(error, exceptionStatus);
   }
 
   @ExceptionHandler


### PR DESCRIPTION
## Summary
- Add explicit exception handler for `bio.terra.common.exception.UnauthorizedException` in `DataRepositoryServiceApiController`
- Add generic exception handler for `bio.terra.common.exception.ErrorReportException` to handle all subclasses with their correct HTTP status codes
- Ensures DRS API exceptions return proper HTTP status codes instead of HTTP 500

## Problem
When `DrsService.lookupObjectByDrsIdPassport()` throws `UnauthorizedException` (e.g., when a user doesn't have passport access to any snapshots), the exception was being caught by the generic `Exception` handler in the controller. This caused:
- The exception to be logged as "Uncaught exception"
- HTTP 500 (Internal Server Error) to be returned instead of HTTP 401 (Unauthorized)

Similarly, other `ErrorReportException` subclasses (like `BadRequestException`, `NotFoundException`, `ForbiddenException`, etc.) were also falling through to the generic handler and returning HTTP 500 instead of their appropriate status codes.

## Root Cause
The controller had specific handlers for `IamUnauthorizedException` and `IamForbiddenException` but not for the base `UnauthorizedException` or `ErrorReportException` classes. Local `@ExceptionHandler` methods in a controller take precedence over global handlers in `@RestControllerAdvice`, so the generic `Exception` handler was catching these exceptions first.

## Solution
1. Added a specific `@ExceptionHandler` for `UnauthorizedException` that returns HTTP 401
2. Added a generic `@ExceptionHandler` for `ErrorReportException` that uses the exception's built-in `getStatusCode()` method to return the correct HTTP status code for all subclasses (e.g., `BadRequestException` → 400, `NotFoundException` → 404, `ForbiddenException` → 403, etc.)

This approach is more maintainable than adding individual handlers for each exception type and ensures consistent behavior across all `ErrorReportException` subclasses.

## Test plan
- [x] Existing unit tests pass
- [ ] Verify in production logs that passport auth failures now return 401 instead of 500
- [ ] Confirm "Uncaught exception" log messages for these scenarios are eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)