### PR TITLE
[CTM-473] Fix NullPointerException when using passport auth with x-user-project header

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -351,6 +351,15 @@ public class DrsService {
       boolean passportAuth) {
 
     Map<UUID, UUID> snapshotToBillingSnapshot = chooseBillingSnapshotsPerSnapshot(cachedSnapshots);
+
+    logger.info(
+        "Resolving DRS object for DRS ID {} with {} snapshots. Billing snapshot mapping: {}",
+        drsId.toDrsObjectId(),
+        cachedSnapshots.size(),
+        snapshotToBillingSnapshot.entrySet().stream()
+            .map(e -> e.getKey() + " -> " + e.getValue())
+            .toList());
+
     List<Future<DRSObject>> futures =
         cachedSnapshots.stream()
             .map(
@@ -556,6 +565,14 @@ public class DrsService {
         throw new BadRequestException(
             "The supplied x-user-project must not be the snapshot's own project");
       }
+      if (authUser == null) {
+        logger.warn(
+            "Using passport auth with requester-pays snapshot {} and userProject '{}'. "
+                + "Will sign with dataset's service account and include userProject parameter, "
+                + "but billing authorization may fail at access time.",
+            cachedSnapshot.id,
+            userProject);
+      }
     }
     if (platform.isGcp()) {
       return signGoogleUrl(cachedSnapshot, fsFile.getCloudPath(), authUser, userProject);
@@ -630,6 +647,14 @@ public class DrsService {
       String gsPath,
       AuthenticatedUserRequest authUser,
       String userProject) {
+    logger.info(
+        "Signing Google URL for snapshot {}: gsPath='{}', userProject='{}', authUser={}, isSelfHosted={}",
+        cachedSnapshot.id,
+        gsPath,
+        userProject,
+        authUser != null ? "present" : "null",
+        cachedSnapshot.isSelfHosted);
+
     BlobId locator = GcsUriUtils.parseBlobUri(gsPath);
 
     BlobInfo blobInfo = BlobInfo.newBuilder(locator).build();
@@ -647,14 +672,34 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        return new DRSAccessURL()
-            .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));
+        // For passport auth, authUser will be null. In that case, we can't sign via SAM because
+        // there is no bearer token. Fall through to signing with the dataset's service account.
+        if (authUser != null) {
+          logger.info(
+              "Signing URL via SAM for snapshot {} with userProject '{}'",
+              cachedSnapshot.id,
+              userProject);
+          return new DRSAccessURL()
+              .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));
+        } else {
+          logger.info(
+              "authUser is null (passport auth), falling through to sign with dataset service account for snapshot {}",
+              cachedSnapshot.id);
+        }
       }
       // In the base case of a self-hosted dataset, use the dataset's service account to sign the
       // url
+      logger.info(
+          "Signing URL with dataset service account for snapshot {} (project: {})",
+          cachedSnapshot.id,
+          cachedSnapshot.datasetProjectId);
       signedUrl =
           signUrlFunction.apply(gcsProjectFactory.getStorage(cachedSnapshot.datasetProjectId));
     } else {
+      logger.info(
+          "Signing URL with snapshot's Google project for snapshot {} (project: {})",
+          cachedSnapshot.id,
+          cachedSnapshot.googleProjectId);
       try (Storage storage = initStorage(cachedSnapshot.googleProjectId)) {
         signedUrl = signUrlFunction.apply(storage);
       } catch (Exception e) {
@@ -662,6 +707,8 @@ public class DrsService {
       }
     }
 
+    logger.info(
+        "Successfully signed URL for snapshot {}", cachedSnapshot.id);
     return new DRSAccessURL().url(signedUrl.toString());
   }
 
@@ -701,6 +748,14 @@ public class DrsService {
     if (signingUser != null) {
       queryParams.put(REQUESTED_BY_QUERY_PARAM, signingUser);
     }
+
+    logger.info(
+        "URL signing options for snapshot {}: signingProject='{}', signingUser='{}', userProject='{}'",
+        cachedSnapshot.id,
+        signingProject,
+        signingUser,
+        userProject);
+
     return new Storage.SignUrlOption[] {
       Storage.SignUrlOption.withQueryParams(queryParams), Storage.SignUrlOption.withV4Signature()
     };
@@ -847,6 +902,15 @@ public class DrsService {
         prefix
             + region
             + Optional.ofNullable(billingProject).map(b -> ACCESS_ID_SEPARATOR + b).orElse("");
+
+    logger.info(
+        "Creating access method: prefix='{}', region='{}', passportAuth={}, billingProject='{}', resulting accessId='{}'",
+        prefix,
+        region,
+        passportAuth,
+        billingProject,
+        accessId);
+
     DRSAccessMethod httpsAccessMethod =
         new DRSAccessMethod()
             .type(DRSAccessMethod.TypeEnum.HTTPS)

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -352,14 +352,6 @@ public class DrsService {
 
     Map<UUID, UUID> snapshotToBillingSnapshot = chooseBillingSnapshotsPerSnapshot(cachedSnapshots);
 
-    logger.info(
-        "Resolving DRS object for DRS ID {} with {} snapshots. Billing snapshot mapping: {}",
-        drsId.toDrsObjectId(),
-        cachedSnapshots.size(),
-        snapshotToBillingSnapshot.entrySet().stream()
-            .map(e -> e.getKey() + " -> " + e.getValue())
-            .toList());
-
     List<Future<DRSObject>> futures =
         cachedSnapshots.stream()
             .map(
@@ -565,14 +557,6 @@ public class DrsService {
         throw new BadRequestException(
             "The supplied x-user-project must not be the snapshot's own project");
       }
-      if (authUser == null) {
-        logger.warn(
-            "Using passport auth with requester-pays snapshot {} and userProject '{}'. "
-                + "Will sign with dataset's service account and include userProject parameter, "
-                + "but billing authorization may fail at access time.",
-            cachedSnapshot.id,
-            userProject);
-      }
     }
     if (platform.isGcp()) {
       return signGoogleUrl(cachedSnapshot, fsFile.getCloudPath(), authUser, userProject);
@@ -707,8 +691,7 @@ public class DrsService {
       }
     }
 
-    logger.info(
-        "Successfully signed URL for snapshot {}", cachedSnapshot.id);
+    logger.info("Successfully signed URL for snapshot {}", cachedSnapshot.id);
     return new DRSAccessURL().url(signedUrl.toString());
   }
 
@@ -902,14 +885,6 @@ public class DrsService {
         prefix
             + region
             + Optional.ofNullable(billingProject).map(b -> ACCESS_ID_SEPARATOR + b).orElse("");
-
-    logger.info(
-        "Creating access method: prefix='{}', region='{}', passportAuth={}, billingProject='{}', resulting accessId='{}'",
-        prefix,
-        region,
-        passportAuth,
-        billingProject,
-        accessId);
 
     DRSAccessMethod httpsAccessMethod =
         new DRSAccessMethod()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-473
## Problem

We discovered a critical bug causing 500 errors when accessing DRS objects via passport authentication with the `x-user-project` header. The error manifested as two distinct failures:

### Error 1: NullPointerException (Primary Bug)
```
NullPointerException: Cannot invoke "bio.terra.common.iam.AuthenticatedUserRequest.getToken()" because "userReq" is null
```

**Stack trace location:** `SamIam.java:829` via `DrsService.java:660`

**Root cause:** When `postAccessUrlForObjectId` is called with passport authentication, it passes `authUser=null` to `getAccessURL`. Later, when signing URLs for self-hosted snapshots with a `userProject`, the code attempts to sign via SAM which calls `userReq.getToken()` on the null object.

### Error 2: "No matching access ID was found for object"
Claude's theory: This secondary error occurred when DRS Hub fell back to GET requests (bearer token auth) after the POST (passport auth) failed. This appears to be a separate issue still under investigation.

## Investigation Details

### Timeline from Production Logs (2026-04-29)
```
15:41:13 - POST /objects/{id} with passport → Success (200)
15:41:14-16 - POST /objects/{id}/access/{accessId} with passport → NullPointerException (500)
15:41:16-18 - GET /objects/{id}/access/{accessId} with bearer → No matching access ID (500)
```

**DRS Hub behavior:** 
1. Tries POST with passport auth → hits NullPointerException
2. Falls back to GET with bearer token → hits different error
3. Both approaches fail, blocking DRS access

### The Signing Flow Issue

When passport authentication is used with `x-user-project`:

**Expected flow (SAM route):**
- User provides bearer token → SAM signs URL on behalf of user → User's project gets billed ✅

**Broken flow (passport route):**
- No user credentials → `authUser=null` → Tries to call SAM → NullPointerException ❌

## Solution

### Use fallback method for signing urls when passport auth is used
```java
if (!StringUtils.isEmpty(userProject)) {
  if (authUser != null) {  // ← NEW CHECK
    return new DRSAccessURL()
        .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));
  }
}
// Fall through to sign with dataset's service account
```
**Q: Why only use the fallback method when the passport is passed in and not always?**

**The dataset's service account signs the URL** (not the user), and includes `?userProject=X` as a query parameter. However, GCS may validate that the signing identity has permission to bill the requester-pays project. This might work or fail depending on the dataset SA's permissions.

**Question for review:** Should we allow this scenario or return an error?
Allowed with this changes because:
- We don't have user credentials to sign via SAM when using a passport
- In theory, Dataset SA can sign its own buckets
- GCS billing validation may happen at access time (not signing time - so, potentially a bad user experience)

### Additional Logging
Added comprehensive logging to understand:
- Whether authUser is null (passport auth)
- Which signing method is used (SAM vs dataset SA)
- What userProject is being billed
- What credentials are used to sign

## Testing
- [ ] Verify passport auth + userProject no longer throws NullPointerException
- [ ] Verify signed URLs are accessible when using dataset SA signing
- [ ] Verify billing is charged to userProject (not dataset project)
- [ ] Check if there are permission issues with dataset SA signing for arbitrary user projects

## Questions for Review

1. **Is passport auth + requester-pays a supported use case?** Should we just not allow this case? Is it a requirement from the users?

2. **Who should sign URLs when we require user project billing?** 
   - SAM route: User's credentials sign → User authorizes billing
   - Our fallback: Dataset SA signs → Can it authorize billing to arbitrary projects?

3. **What happens at access time?** Will GCS reject signed URLs where the signer (dataset SA) doesn't have permission on the billing project?

## Related Logs
- Production error: https://console.cloud.google.com/logs/query;...insertId=g0l8yec7xmhwxb7w
- DRS Hub logs: https://console.cloud.google.com/logs/query;...drshub-deployment...


# Rollout Plan

My proposal is that we roll this change out to prod and test there. This is a conservative change: It should still work for any case that was working before because we only add branching logic if there is not AuthenticatedUserRequest information, which would fail anyway. This will allow us to move faster with testing. 