### PR TITLE
Pass bearer token for passport auth with userProject

### DIFF
--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -166,9 +166,14 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         objectId,
         accessId,
         userProject);
+    AuthenticatedUserRequest authUserOnlyForUserProjectAccess = getAuthenticatedInfo();
     DRSAccessURL accessURL =
         drsService.postAccessUrlForObjectId(
-            objectId, accessId, drsPassportRequestModel, userProject);
+            authUserOnlyForUserProjectAccess,
+            objectId,
+            accessId,
+            drsPassportRequestModel,
+            userProject);
     return new ResponseEntity<>(accessURL, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -668,7 +668,7 @@ public class DrsService {
         } else {
           throw new InvalidAuthorizationMethod(
               String.format(
-                  "When providing a userProject, the bearer token authorization must also be provided in addition to the passport for snapshot %s and userProject %s",
+                  "Bearer token required when using userProject with passport auth (snapshot: %s, userProject: %s)",
                   cachedSnapshot.id, userProject));
         }
       }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -34,6 +34,7 @@ import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
+import bio.terra.service.auth.ras.exception.InvalidAuthorizationMethod;
 import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.filedata.DrsDao.DrsAlias;
 import bio.terra.service.filedata.azure.blobstore.AzureBlobStorePdao;
@@ -495,12 +496,13 @@ public class DrsService {
   }
 
   public DRSAccessURL postAccessUrlForObjectId(
+      AuthenticatedUserRequest authUserOnlyForUserProjectAccess,
       String objectId,
       String accessId,
       DRSPassportRequestModel passportRequestModel,
       String userProject) {
     DRSObject drsObject = lookupObjectByDrsIdPassport(objectId, passportRequestModel);
-    return getAccessURL(null, drsObject, accessId, userProject);
+    return getAccessURL(authUserOnlyForUserProjectAccess, drsObject, accessId, userProject);
   }
 
   public DRSAccessURL getAccessUrlForObjectId(
@@ -656,8 +658,6 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        // For passport auth, authUser will be null. In that case, we can't sign via SAM because
-        // there is no bearer token. Fall through to signing with the dataset's service account.
         if (authUser != null) {
           logger.info(
               "Signing URL via SAM for snapshot {} with userProject '{}'",
@@ -666,9 +666,10 @@ public class DrsService {
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));
         } else {
-          logger.info(
-              "authUser is null (passport auth), falling through to sign with dataset service account for snapshot {}",
-              cachedSnapshot.id);
+          throw new InvalidAuthorizationMethod(
+              String.format(
+                  "When providing a userProject, the bearer token authorization must also be provided in addition to the passport for snapshot %s and userProject %s",
+                  cachedSnapshot.id, userProject));
         }
       }
       // In the base case of a self-hosted dataset, use the dataset's service account to sign the

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -109,7 +109,7 @@ class DataRepositoryServiceApiControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtils.mapToJson(PASSPORT)));
 
-    when(drsService.postAccessUrlForObjectId(DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenThrow(DrsObjectNotFoundException.class);
     mvc.perform(
             post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
@@ -128,7 +128,7 @@ class DataRepositoryServiceApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(DRS_ID));
 
-    when(drsService.postAccessUrlForObjectId(DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
     mvc.perform(
             post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
@@ -211,7 +211,8 @@ class DataRepositoryServiceApiControllerTest {
   @Test
   void testPostAccessURLLogsUserProject() throws Exception {
     String userProject = "my-gcp-project";
-    when(drsService.postAccessUrlForObjectId(DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+    when(drsService.postAccessUrlForObjectId(
+            TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =
@@ -247,7 +248,7 @@ class DataRepositoryServiceApiControllerTest {
 
   @Test
   void testPostAccessURLLogsNullUserProject() throws Exception {
-    when(drsService.postAccessUrlForObjectId(DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -20,6 +20,7 @@ import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSAuthorizations;
 import bio.terra.model.DRSObject;
 import bio.terra.model.DRSPassportRequestModel;
+import bio.terra.service.auth.ras.exception.InvalidAuthorizationMethod;
 import bio.terra.service.filedata.DrsService;
 import bio.terra.service.filedata.exception.DrsObjectNotFoundException;
 import ch.qos.logback.classic.Logger;
@@ -275,6 +276,23 @@ class DataRepositoryServiceApiControllerTest {
     } finally {
       controllerLogger.detachAppender(listAppender);
     }
+  }
+
+  @Test
+  void testPostAccessURLRequiresBearerTokenWithUserProject() throws Exception {
+    String userProject = "my-gcp-project";
+    when(drsService.postAccessUrlForObjectId(
+            TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+        .thenThrow(
+            new InvalidAuthorizationMethod(
+                "Bearer token required when using userProject with passport auth"));
+
+    mvc.perform(
+            post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
+                .header("x-user-project", userProject)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(PASSPORT)))
+        .andExpect(status().isUnauthorized());
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -740,6 +740,7 @@ class DrsServiceTest {
     when(drsService.initStorage(snapshotProject)).thenReturn(storage);
     DRSAccessURL url =
         drsService.postAccessUrlForObjectId(
+            TEST_USER,
             googleDrsObjectId,
             "gcp-passport-us-central1*" + snapshotId,
             drsPassportRequestModel,
@@ -761,7 +762,11 @@ class DrsServiceTest {
         UnauthorizedException.class,
         () ->
             drsService.postAccessUrlForObjectId(
-                googleDrsObjectId, "gcp-passport-us-central1", drsPassportRequestModel, null));
+                TEST_USER,
+                googleDrsObjectId,
+                "gcp-passport-us-central1",
+                drsPassportRequestModel,
+                null));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-473

## Summary
- Pass authenticated user (bearer token) through to DRS service even when using passport authentication
- Improve error handling when userProject is specified without bearer token
- Add test coverage for the error case

## Background
Previously, when using passport authentication with the `x-user-project` header, the `authUser` would be null, preventing URL signing via SAM. This would silently fall back to signing with the dataset's service account, which could fail or behave unexpectedly.

## Changes
1. **Controller**: Capture `AuthenticatedUserRequest` and pass it to `DrsService.postAccessUrlForObjectId()`
2. **Service**: Accept the auth user parameter and use it for SAM signing when userProject is specified
3. **Error handling**: Throw explicit `InvalidAuthorizationMethod` exception when userProject is provided without bearer token, with clear error message
4. **Tests**: 
   - Updated all existing tests to include the new parameter
   - Added new test `testPostAccessURLRequiresBearerTokenWithUserProject()` to verify proper error handling

## Test Plan
- [x] All existing unit tests pass
- [x] New test verifies InvalidAuthorizationMethod is thrown with appropriate status code
- [ ] Manual testing with passport auth + userProject header
- [ ] Verify SAM URL signing works correctly with both auth methods

🤖 Generated with [Claude Code](https://claude.ai/claude-code)