### PR TITLE
CTM-394: guard against empty access token when signing url via Sam

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -658,7 +658,7 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        if (authUser != null) {
+        if (authUser != null && authUser.getToken() != null && !authUser.getToken().isBlank()) {
           logger.info(
               "Signing URL via SAM for snapshot {} with userProject '{}'",
               cachedSnapshot.id,


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-394

When signing a url via Sam, adds validation that we have a non-blank access token to send to Sam.