### PR TITLE
CTM-473: Require non-empty tokens; switch to BearerTokenFactory for PostAccessURL

### DIFF
--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -77,16 +77,18 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
-    var authHeader = Optional.of(request.getHeader("Authorization")).orElse("#header did not exist#");
-    var tokenHeader = Optional.of(request.getHeader("OIDC_ACCESS_token")).orElse("#header did not exist#");
+    var authHeader =
+        Optional.of(request.getHeader("Authorization")).orElse("#header did not exist#");
+    var tokenHeader =
+        Optional.of(request.getHeader("OIDC_ACCESS_token")).orElse("#header did not exist#");
 
     var authHeaderWithoutPrefix = authHeader.replaceFirst("Bearer ", "");
 
-    var authSample = authHeaderWithoutPrefix.subSequence(0, Math.min(25, authHeaderWithoutPrefix.length()));
+    var authSample =
+        authHeaderWithoutPrefix.subSequence(0, Math.min(25, authHeaderWithoutPrefix.length()));
     var tokenSample = tokenHeader.subSequence(0, Math.min(25, tokenHeader.length()));
 
     var isEqual = tokenHeader.equals(authHeaderWithoutPrefix);
-
 
     var authenticatedUserRequest = authenticatedUserRequestFactory.from(request);
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -24,7 +24,9 @@ import bio.terra.service.filedata.exception.InvalidDrsIdException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,8 +83,6 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
     var authSample = authHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
     var tokenSample = tokenHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
 
-    var isSameToken = authHeader.equals(tokenHeader);
-
     var authenticatedUserRequest = authenticatedUserRequestFactory.from(request);
 
     var userObjectSample =
@@ -90,13 +90,13 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
             .map(s -> s.subSequence(0, Math.min(25, s.length())));
 
     logger.info(
-        "getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}] | user object: [{}]",
+        "getAuthenticatedInfo for {} {}, auth header: [{}] | token header: [{}] | user object: [{}] | header names: [{}]",
         request.getMethod(),
         request.getRequestURI(),
-        isSameToken,
         authSample,
         tokenSample,
-        userObjectSample);
+        userObjectSample,
+        StringUtils.joinWith(",", Collections.list(request.getHeaderNames()).toArray()));
 
     return authenticatedUserRequestFactory.from(request);
   }

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -171,12 +171,12 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         accessId,
         userProject);
     /*
-     Use BearerTokenFactory to get token from Authorization header.
-       Because this endpoint lives under /ga4gh instead of /api, TDR's auth proxy does not
-       set OIDC_CLAIM_email and OIDC_CLAIM_user_id headers. Because those headers are not set,
-       the ProxiedAuthenticatedUserRequestFactory class will fail to create an AuthenticatedUserRequest
-       object. Therefore, we must create a BearerToken instead of using getAuthenticatedInfo() to
-       create an AuthenticatedUserRequest like other endpoints do.
+     Use BearerTokenFactory to get the token from Authorization header.
+       Because this endpoint lives under /ga4gh instead of /api, TDR's auth proxy always sets the
+       OIDC_CLAIM_email and OIDC_CLAIM_user_id headers to the empty string. Because those headers are
+       empty, the ProxiedAuthenticatedUserRequestFactory class will fail to create an
+       AuthenticatedUserRequest object. Therefore, we must create a BearerToken instead of using
+       getAuthenticatedInfo() to create an AuthenticatedUserRequest like other endpoints do.
     */
     var bearerToken = bearerTokenFactory.from(request);
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -203,18 +203,12 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         objectId,
         accessId,
         userProject);
-    //    // Use BearerTokenFactory to get token from Authorization header
-    //    var bearerToken = bearerTokenFactory.from(request);
-
-    AuthenticatedUserRequest authUserOnlyForUserProjectAccess = getAuthenticatedInfo();
+    // Use BearerTokenFactory to get token from Authorization header
+    var bearerToken = bearerTokenFactory.from(request);
 
     DRSAccessURL accessURL =
         drsService.postAccessUrlForObjectId(
-            authUserOnlyForUserProjectAccess,
-            objectId,
-            accessId,
-            drsPassportRequestModel,
-            userProject);
+            bearerToken, objectId, accessId, drsPassportRequestModel, userProject);
     return new ResponseEntity<>(accessURL, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -203,7 +203,14 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         objectId,
         accessId,
         userProject);
-    // Use BearerTokenFactory to get token from Authorization header
+    /*
+     Use BearerTokenFactory to get token from Authorization header.
+       Because this endpoint lives under /ga4gh instead of /api, TDR's auth proxy does not
+       set OIDC_CLAIM_email and OIDC_CLAIM_user_id headers. Because those headers are not set,
+       the ProxiedAuthenticatedUserRequestFactory class will fail to create an AuthenticatedUserRequest
+       object. Therefore, we must create a BearerToken instead of an AuthenticatedUserRequest like
+       other endpoints do.
+    */
     var bearerToken = bearerTokenFactory.from(request);
 
     DRSAccessURL accessURL =

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -79,15 +79,22 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
 
     var isSameToken = authHeader.equals(tokenHeader);
 
+    var authenticatedUserRequest = authenticatedUserRequestFactory.from(request);
+
+    var userObjectSample =
+        Optional.ofNullable(authenticatedUserRequest.getToken())
+            .map(s -> s.subSequence(0, Math.min(25, s.length())));
+
     logger.info(
-        "getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}]",
+        "getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}] | user object: [{}]",
         request.getMethod(),
         request.getRequestURI(),
         isSameToken,
         authSample,
-        tokenSample);
+        tokenSample,
+        userObjectSample);
 
-    return authenticatedUserRequestFactory.from(request);
+    return authenticatedUserRequest;
   }
 
   @ExceptionHandler

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -71,6 +71,19 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
+    var authHeader = Optional.of(request.getHeader("Authorization"));
+    var tokenHeader = Optional.of(request.getHeader("OIDC_ACCESS_token"));
+
+    var authSample = authHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
+    var tokenSample = tokenHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
+
+    var isSameToken = authHeader.equals(tokenHeader);
+
+    logger.info("getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}]",
+        request.getMethod(),
+        request.getRequestURI(),
+        isSameToken, authSample, tokenSample);
+
     return authenticatedUserRequestFactory.from(request);
   }
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -24,9 +24,7 @@ import bio.terra.service.filedata.exception.InvalidDrsIdException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Collections;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -177,8 +175,8 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
        Because this endpoint lives under /ga4gh instead of /api, TDR's auth proxy does not
        set OIDC_CLAIM_email and OIDC_CLAIM_user_id headers. Because those headers are not set,
        the ProxiedAuthenticatedUserRequestFactory class will fail to create an AuthenticatedUserRequest
-       object. Therefore, we must create a BearerToken instead of an AuthenticatedUserRequest like
-       other endpoints do.
+       object. Therefore, we must create a BearerToken instead of using getAuthenticatedInfo() to
+       create an AuthenticatedUserRequest like other endpoints do.
     */
     var bearerToken = bearerTokenFactory.from(request);
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -77,11 +77,16 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
-    var authHeader = Optional.of(request.getHeader("Authorization"));
-    var tokenHeader = Optional.of(request.getHeader("OIDC_ACCESS_token"));
+    var authHeader = Optional.of(request.getHeader("Authorization")).orElse("#header did not exist#");
+    var tokenHeader = Optional.of(request.getHeader("OIDC_ACCESS_token")).orElse("#header did not exist#");
 
-    var authSample = authHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
-    var tokenSample = tokenHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
+    var authHeaderWithoutPrefix = authHeader.replaceFirst("Bearer ", "");
+
+    var authSample = authHeaderWithoutPrefix.subSequence(0, Math.min(25, authHeaderWithoutPrefix.length()));
+    var tokenSample = tokenHeader.subSequence(0, Math.min(25, tokenHeader.length()));
+
+    var isEqual = tokenHeader.equals(authHeaderWithoutPrefix);
+
 
     var authenticatedUserRequest = authenticatedUserRequestFactory.from(request);
 
@@ -90,9 +95,10 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
             .map(s -> s.subSequence(0, Math.min(25, s.length())));
 
     logger.info(
-        "getAuthenticatedInfo for {} {}, auth header: [{}] | token header: [{}] | user object: [{}] | header names: [{}]",
+        "getAuthenticatedInfo for {} {}, headers equal? {} | auth header: [{}] | token header: [{}] | user object: [{}] | header names: [{}]",
         request.getMethod(),
         request.getRequestURI(),
+        isEqual,
         authSample,
         tokenSample,
         userObjectSample,

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -79,10 +79,13 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
 
     var isSameToken = authHeader.equals(tokenHeader);
 
-    logger.info("getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}]",
+    logger.info(
+        "getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}]",
         request.getMethod(),
         request.getRequestURI(),
-        isSameToken, authSample, tokenSample);
+        isSameToken,
+        authSample,
+        tokenSample);
 
     return authenticatedUserRequestFactory.from(request);
   }

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -95,13 +95,15 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
             .map(s -> s.subSequence(0, Math.min(25, s.length())));
 
     logger.info(
-        "getAuthenticatedInfo for {} {}, headers equal? {} | auth header: [{}] | token header: [{}] | user object: [{}] | header names: [{}]",
+        "getAuthenticatedInfo for {} {}, headers equal? {} | auth header: [{}] | token header: [{}] | user object: [{}] | email header: [{}] | userid header: [{}] | header names: [{}]",
         request.getMethod(),
         request.getRequestURI(),
         isEqual,
         authSample,
         tokenSample,
         userObjectSample,
+        request.getHeader("OIDC_CLAIM_email"),
+        request.getHeader("OIDC_CLAIM_user_id"),
         StringUtils.joinWith(",", Collections.list(request.getHeaderNames()).toArray()));
 
     return authenticatedUserRequestFactory.from(request);

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -203,11 +203,18 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         objectId,
         accessId,
         userProject);
-    // Use BearerTokenFactory to get token from Authorization header
-    var bearerToken = bearerTokenFactory.from(request);
+    //    // Use BearerTokenFactory to get token from Authorization header
+    //    var bearerToken = bearerTokenFactory.from(request);
+
+    AuthenticatedUserRequest authUserOnlyForUserProjectAccess = getAuthenticatedInfo();
+
     DRSAccessURL accessURL =
         drsService.postAccessUrlForObjectId(
-            bearerToken, objectId, accessId, drsPassportRequestModel, userProject);
+            authUserOnlyForUserProjectAccess,
+            objectId,
+            accessId,
+            drsPassportRequestModel,
+            userProject);
     return new ResponseEntity<>(accessURL, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -77,37 +77,6 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
-    var authHeader =
-        Optional.of(request.getHeader("Authorization")).orElse("#header did not exist#");
-    var tokenHeader =
-        Optional.of(request.getHeader("OIDC_ACCESS_token")).orElse("#header did not exist#");
-
-    var authHeaderWithoutPrefix = authHeader.replaceFirst("Bearer ", "");
-
-    var authSample =
-        authHeaderWithoutPrefix.subSequence(0, Math.min(25, authHeaderWithoutPrefix.length()));
-    var tokenSample = tokenHeader.subSequence(0, Math.min(25, tokenHeader.length()));
-
-    var isEqual = tokenHeader.equals(authHeaderWithoutPrefix);
-
-    var authenticatedUserRequest = authenticatedUserRequestFactory.from(request);
-
-    var userObjectSample =
-        Optional.ofNullable(authenticatedUserRequest.getToken())
-            .map(s -> s.subSequence(0, Math.min(25, s.length())));
-
-    logger.info(
-        "getAuthenticatedInfo for {} {}, headers equal? {} | auth header: [{}] | token header: [{}] | user object: [{}] | email header: [{}] | userid header: [{}] | header names: [{}]",
-        request.getMethod(),
-        request.getRequestURI(),
-        isEqual,
-        authSample,
-        tokenSample,
-        userObjectSample,
-        request.getHeader("OIDC_CLAIM_email"),
-        request.getHeader("OIDC_CLAIM_user_id"),
-        StringUtils.joinWith(",", Collections.list(request.getHeaderNames()).toArray()));
-
     return authenticatedUserRequestFactory.from(request);
   }
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,12 +75,8 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
-    // Use BearerTokenFactory to extract token from Authorization header
-    var bearerToken = bearerTokenFactory.from(request);
-    String token = bearerToken != null ? bearerToken.getToken() : null;
-
-    var authHeader = Optional.ofNullable(request.getHeader("Authorization"));
-    var tokenHeader = Optional.ofNullable(request.getHeader("OIDC_ACCESS_token"));
+    var authHeader = Optional.of(request.getHeader("Authorization"));
+    var tokenHeader = Optional.of(request.getHeader("OIDC_ACCESS_token"));
 
     var authSample = authHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
     var tokenSample = tokenHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
@@ -98,22 +93,12 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         "getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}] | user object: [{}]",
         request.getMethod(),
         request.getRequestURI(),
+        isSameToken,
         authSample,
         tokenSample,
         userObjectSample);
 
-    // Use the deprecated factory for now, but with the token from BearerTokenFactory
-    AuthenticatedUserRequest authUser = authenticatedUserRequestFactory.from(request);
-    // Override with the correct token from Authorization header if it was empty
-    if (StringUtils.isEmpty(authUser.getToken()) && token != null) {
-      logger.info("Token was empty from factory, using token from BearerTokenFactory");
-      return AuthenticatedUserRequest.builder()
-          .setEmail(authUser.getEmail())
-          .setSubjectId(authUser.getSubjectId())
-          .setToken(token)
-          .build();
-    }
-    return authUser;
+    return authenticatedUserRequestFactory.from(request);
   }
 
   @ExceptionHandler
@@ -208,14 +193,11 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
         objectId,
         accessId,
         userProject);
-    AuthenticatedUserRequest authUserOnlyForUserProjectAccess = getAuthenticatedInfo();
+    // Use BearerTokenFactory to get token from Authorization header
+    var bearerToken = bearerTokenFactory.from(request);
     DRSAccessURL accessURL =
         drsService.postAccessUrlForObjectId(
-            authUserOnlyForUserProjectAccess,
-            objectId,
-            accessId,
-            drsPassportRequestModel,
-            userProject);
+            bearerToken, objectId, accessId, drsPassportRequestModel, userProject);
     return new ResponseEntity<>(accessURL, HttpStatus.OK);
   }
 

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -9,6 +9,7 @@ import bio.terra.common.exception.NotImplementedException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.controller.DataRepositoryServiceApi;
 import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSAuthorizations;
@@ -24,6 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,7 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   private final HttpServletRequest request;
   private final DrsService drsService;
   private final AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  private final BearerTokenFactory bearerTokenFactory;
 
   // needed for local testing w/o proxy
   private final ApplicationConfiguration appConfig;
@@ -52,12 +55,14 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
       HttpServletRequest request,
       DrsService drsService,
       ApplicationConfiguration appConfig,
-      AuthenticatedUserRequestFactory authenticatedUserRequestFactory) {
+      AuthenticatedUserRequestFactory authenticatedUserRequestFactory,
+      BearerTokenFactory bearerTokenFactory) {
     this.objectMapper = objectMapper;
     this.request = request;
     this.appConfig = appConfig;
     this.drsService = drsService;
     this.authenticatedUserRequestFactory = authenticatedUserRequestFactory;
+    this.bearerTokenFactory = bearerTokenFactory;
   }
 
   @Override
@@ -71,23 +76,36 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
   }
 
   private AuthenticatedUserRequest getAuthenticatedInfo() {
-    var authHeader = Optional.of(request.getHeader("Authorization"));
-    var tokenHeader = Optional.of(request.getHeader("OIDC_ACCESS_token"));
+    // Use BearerTokenFactory to extract token from Authorization header
+    var bearerToken = bearerTokenFactory.from(request);
+    String token = bearerToken != null ? bearerToken.getToken() : null;
+
+    var authHeader = Optional.ofNullable(request.getHeader("Authorization"));
+    var tokenHeader = Optional.ofNullable(request.getHeader("OIDC_ACCESS_token"));
 
     var authSample = authHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
     var tokenSample = tokenHeader.map(s -> s.subSequence(0, Math.min(25, s.length())));
 
-    var isSameToken = authHeader.equals(tokenHeader);
-
     logger.info(
-        "getAuthenticatedInfo for {} {} headers equal? {}, auth header: [{}] | token header: [{}]",
+        "getAuthenticatedInfo for {} {} - auth header: [{}] | token header: [{}] | extracted token length: {}",
         request.getMethod(),
         request.getRequestURI(),
-        isSameToken,
         authSample,
-        tokenSample);
+        tokenSample,
+        token != null ? token.length() : 0);
 
-    return authenticatedUserRequestFactory.from(request);
+    // Use the deprecated factory for now, but with the token from BearerTokenFactory
+    AuthenticatedUserRequest authUser = authenticatedUserRequestFactory.from(request);
+    // Override with the correct token from Authorization header if it was empty
+    if (StringUtils.isEmpty(authUser.getToken()) && token != null) {
+      logger.info("Token was empty from factory, using token from BearerTokenFactory");
+      return AuthenticatedUserRequest.builder()
+          .setEmail(authUser.getEmail())
+          .setSubjectId(authUser.getSubjectId())
+          .setToken(token)
+          .build();
+    }
+    return authUser;
   }
 
   @ExceptionHandler

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -505,6 +505,21 @@ public class DrsService {
     return getAccessURL(authUserOnlyForUserProjectAccess, drsObject, accessId, userProject);
   }
 
+  public DRSAccessURL postAccessUrlForObjectId(
+      bio.terra.common.iam.BearerToken bearerToken,
+      String objectId,
+      String accessId,
+      DRSPassportRequestModel passportRequestModel,
+      String userProject) {
+    DRSObject drsObject = lookupObjectByDrsIdPassport(objectId, passportRequestModel);
+    // Build AuthenticatedUserRequest from BearerToken for SAM
+    AuthenticatedUserRequest authUser =
+        AuthenticatedUserRequest.builder()
+            .setToken(bearerToken != null ? bearerToken.getToken() : null)
+            .build();
+    return getAccessURL(authUser, drsObject, accessId, userProject);
+  }
+
   public DRSAccessURL getAccessUrlForObjectId(
       AuthenticatedUserRequest authUser, String objectId, String accessId, String userProject) {
     DRSObject drsObject = lookupObjectByDrsId(authUser, objectId, false);

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -663,7 +663,7 @@ public class DrsService {
               "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
               cachedSnapshot.id,
               userProject,
-              authUser.getToken().subSequence(0, 5),
+              authUser.getToken().subSequence(0, 15),
               authUser.getToken().length());
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -17,6 +17,7 @@ import bio.terra.common.exception.FeatureNotImplementedException;
 import bio.terra.common.exception.InvalidCloudPlatformException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.iam.BearerToken;
 import bio.terra.externalcreds.model.ValidatePassportResult;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
@@ -496,23 +497,18 @@ public class DrsService {
   }
 
   public DRSAccessURL postAccessUrlForObjectId(
-      AuthenticatedUserRequest authUserOnlyForUserProjectAccess,
+      BearerToken bearerToken,
       String objectId,
       String accessId,
       DRSPassportRequestModel passportRequestModel,
       String userProject) {
     DRSObject drsObject = lookupObjectByDrsIdPassport(objectId, passportRequestModel);
-    return getAccessURL(authUserOnlyForUserProjectAccess, drsObject, accessId, userProject);
-  }
-
-  public DRSAccessURL postAccessUrlForObjectId(
-      bio.terra.common.iam.BearerToken bearerToken,
-      String objectId,
-      String accessId,
-      DRSPassportRequestModel passportRequestModel,
-      String userProject) {
-    DRSObject drsObject = lookupObjectByDrsIdPassport(objectId, passportRequestModel);
-    // Build AuthenticatedUserRequest from BearerToken for SAM
+    /* Translate the BearerToken to an AuthenticatedUserRequest.
+       The BearerToken comes from the /ga4gh/drs/v1/objects/{object_id}/access/{access_id} endpoint,
+       which only has an access token and does not have the user's email or subjectid.
+       Because AuthenticatedUserRequest requires email/subjectid, we have to supply dummy
+       values.
+    */
     AuthenticatedUserRequest authUser =
         AuthenticatedUserRequest.builder()
             .setToken(bearerToken != null ? bearerToken.getToken() : null)

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -516,6 +516,8 @@ public class DrsService {
     AuthenticatedUserRequest authUser =
         AuthenticatedUserRequest.builder()
             .setToken(bearerToken != null ? bearerToken.getToken() : null)
+            .setEmail("n/a")
+            .setSubjectId("n/a")
             .build();
     return getAccessURL(authUser, drsObject, accessId, userProject);
   }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -658,9 +658,7 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        if (authUser != null
-            && authUser.getToken() != null
-            && StringUtils.isNotEmpty(authUser.getToken())) {
+        if (authUser != null && StringUtils.isNotEmpty(authUser.getToken())) {
           logger.info(
               "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
               cachedSnapshot.id,

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -658,11 +658,13 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        if (authUser != null) {
+        if (authUser != null && authUser.getToken() != null) {
           logger.info(
-              "Signing URL via SAM for snapshot {} with userProject '{}'",
+              "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
               cachedSnapshot.id,
-              userProject);
+              userProject,
+              authUser.getToken().subSequence(0,5),
+              authUser.getToken().length());
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));
         } else {

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -658,12 +658,14 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        if (authUser != null && authUser.getToken() != null) {
+        if (authUser != null
+            && authUser.getToken() != null
+            && StringUtils.isNotEmpty(authUser.getToken())) {
           logger.info(
               "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
               cachedSnapshot.id,
               userProject,
-              authUser.getToken().subSequence(0,5),
+              authUser.getToken().subSequence(0, 5),
               authUser.getToken().length());
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -663,7 +663,7 @@ public class DrsService {
               "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
               cachedSnapshot.id,
               userProject,
-              authUser.getToken().subSequence(0, Math.min(15, authUser.getToken().length())),
+              authUser.getToken().subSequence(0, Math.min(16, authUser.getToken().length())),
               authUser.getToken().length());
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -509,13 +509,13 @@ public class DrsService {
        Because AuthenticatedUserRequest requires email/subjectid, we have to supply dummy
        values.
     */
-    AuthenticatedUserRequest authUser =
+    AuthenticatedUserRequest authUserOnlyForUserProjectAccess =
         AuthenticatedUserRequest.builder()
             .setToken(bearerToken != null ? bearerToken.getToken() : null)
             .setEmail("n/a")
             .setSubjectId("n/a")
             .build();
-    return getAccessURL(authUser, drsObject, accessId, userProject);
+    return getAccessURL(authUserOnlyForUserProjectAccess, drsObject, accessId, userProject);
   }
 
   public DRSAccessURL getAccessUrlForObjectId(
@@ -671,13 +671,11 @@ public class DrsService {
       // If a userProject is explicitly passed in, then use that to sign the url.
       // Note: the expectation is that this is a Terra hosted bucket
       if (!StringUtils.isEmpty(userProject)) {
-        if (authUser != null && StringUtils.isNotEmpty(authUser.getToken())) {
+        if (authUser != null && StringUtils.isNotBlank(authUser.getToken())) {
           logger.info(
-              "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
+              "Signing URL via SAM for snapshot {} with userProject '{}'",
               cachedSnapshot.id,
-              userProject,
-              authUser.getToken().subSequence(0, Math.min(16, authUser.getToken().length())),
-              authUser.getToken().length());
+              userProject);
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));
         } else {

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -663,7 +663,7 @@ public class DrsService {
               "Signing URL via SAM for snapshot {} with userProject '{}' and token (starts with {} has length {})",
               cachedSnapshot.id,
               userProject,
-              authUser.getToken().subSequence(0, 15),
+              authUser.getToken().subSequence(0, Math.min(15, authUser.getToken().length())),
               authUser.getToken().length());
           return new DRSAccessURL()
               .url(samService.signUrlForBlob(authUser, userProject, gsPath, URL_TTL));

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -16,6 +16,7 @@ import bio.terra.common.category.Unit;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.common.iam.BearerToken;
 import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSAuthorizations;
 import bio.terra.model.DRSObject;
@@ -68,6 +69,8 @@ class DataRepositoryServiceApiControllerTest {
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
 
+  private static final BearerToken TEST_TOKEN = new BearerToken(TEST_USER.getToken());
+
   @BeforeEach
   void setUp() {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
@@ -110,7 +113,7 @@ class DataRepositoryServiceApiControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtils.mapToJson(PASSPORT)));
 
-    when(drsService.postAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenThrow(DrsObjectNotFoundException.class);
     mvc.perform(
             post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
@@ -129,7 +132,7 @@ class DataRepositoryServiceApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(DRS_ID));
 
-    when(drsService.postAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
     mvc.perform(
             post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
@@ -213,7 +216,7 @@ class DataRepositoryServiceApiControllerTest {
   void testPostAccessURLLogsUserProject() throws Exception {
     String userProject = "my-gcp-project";
     when(drsService.postAccessUrlForObjectId(
-            TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+        TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =
@@ -249,7 +252,7 @@ class DataRepositoryServiceApiControllerTest {
 
   @Test
   void testPostAccessURLLogsNullUserProject() throws Exception {
-    when(drsService.postAccessUrlForObjectId(TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =
@@ -282,7 +285,7 @@ class DataRepositoryServiceApiControllerTest {
   void testPostAccessURLRequiresBearerTokenWithUserProject() throws Exception {
     String userProject = "my-gcp-project";
     when(drsService.postAccessUrlForObjectId(
-            TEST_USER, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+        TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenThrow(
             new InvalidAuthorizationMethod(
                 "Bearer token required when using userProject with passport auth"));

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -216,7 +216,7 @@ class DataRepositoryServiceApiControllerTest {
   void testPostAccessURLLogsUserProject() throws Exception {
     String userProject = "my-gcp-project";
     when(drsService.postAccessUrlForObjectId(
-        TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+            TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =
@@ -285,7 +285,7 @@ class DataRepositoryServiceApiControllerTest {
   void testPostAccessURLRequiresBearerTokenWithUserProject() throws Exception {
     String userProject = "my-gcp-project";
     when(drsService.postAccessUrlForObjectId(
-        TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+            TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenThrow(
             new InvalidAuthorizationMethod(
                 "Bearer token required when using userProject with passport auth"));

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -17,6 +17,7 @@ import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import bio.terra.common.iam.BearerToken;
+import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.model.DRSAccessURL;
 import bio.terra.model.DRSAuthorizations;
 import bio.terra.model.DRSObject;
@@ -65,6 +66,7 @@ class DataRepositoryServiceApiControllerTest {
   @MockitoBean private ApplicationConfiguration applicationConfiguration;
   @MockitoBean private DrsService drsService;
   @MockitoBean private AuthenticatedUserRequestFactory authenticatedUserRequestFactory;
+  @MockitoBean private BearerTokenFactory bearerTokenFactory;
 
   private static final AuthenticatedUserRequest TEST_USER =
       AuthenticationFixtures.randomUserRequest();
@@ -74,6 +76,7 @@ class DataRepositoryServiceApiControllerTest {
   @BeforeEach
   void setUp() {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
+    when(bearerTokenFactory.from(any())).thenReturn(TEST_TOKEN);
   }
 
   @Test

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -38,7 +38,9 @@ import bio.terra.common.UriUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.UnauthorizedException;
+import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
+import bio.terra.common.iam.BearerToken;
 import bio.terra.externalcreds.model.ValidatePassportResult;
 import bio.terra.model.BillingProfileModel;
 import bio.terra.model.CloudPlatform;
@@ -124,6 +126,8 @@ class DrsServiceTest {
           .setEmail("dataset@unit.com")
           .setToken("token")
           .build();
+
+  private static final BearerToken TEST_TOKEN = new BearerToken(TEST_USER.getToken());
 
   private static final String RAS_ISSUER = "https://stsstg.nih.gov";
   private static final String SNAPSHOT_DATA_PROJECT = "snapshot-google-project";
@@ -741,7 +745,7 @@ class DrsServiceTest {
     when(drsService.initStorage(snapshotProject)).thenReturn(storage);
     DRSAccessURL url =
         drsService.postAccessUrlForObjectId(
-            TEST_USER,
+            TEST_TOKEN,
             googleDrsObjectId,
             "gcp-passport-us-central1*" + snapshotId,
             drsPassportRequestModel,
@@ -763,7 +767,7 @@ class DrsServiceTest {
         UnauthorizedException.class,
         () ->
             drsService.postAccessUrlForObjectId(
-                TEST_USER,
+                TEST_TOKEN,
                 googleDrsObjectId,
                 "gcp-passport-us-central1",
                 drsPassportRequestModel,

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -38,7 +38,6 @@ import bio.terra.common.UriUtils;
 import bio.terra.common.category.Unit;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.UnauthorizedException;
-import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.externalcreds.model.ValidatePassportResult;

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -55,6 +55,7 @@ import bio.terra.service.auth.iam.IamAction;
 import bio.terra.service.auth.iam.IamResourceType;
 import bio.terra.service.auth.iam.IamService;
 import bio.terra.service.auth.iam.exception.IamForbiddenException;
+import bio.terra.service.auth.ras.exception.InvalidAuthorizationMethod;
 import bio.terra.service.common.gcs.GcsUriUtils;
 import bio.terra.service.dataset.Dataset;
 import bio.terra.service.dataset.DatasetSummary;
@@ -903,6 +904,69 @@ class DrsServiceTest {
         "contains requester email",
         UriUtils.getValueFromQueryParameter(url.getUrl(), GcsConstants.REQUESTED_BY_QUERY_PARAM),
         equalTo(TEST_USER.getEmail()));
+  }
+
+  private static Stream<Arguments> testSignGcpUrlWithTokenVariations() {
+    return Stream.of(
+        arguments("", true), // empty token should throw
+        arguments("valid-bearer-token-123456", false)); // valid token should not throw
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void testSignGcpUrlWithTokenVariations(String token, boolean shouldThrow) {
+    // Test token validation for self-hosted with userProject
+    SnapshotSummaryModel snapshotSummary =
+        new SnapshotSummaryModel().id(snapshotId).selfHosted(true);
+    Snapshot snapshot =
+        mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
+    snapshot.getSourceDataset().getDatasetSummary().selfHosted(true);
+    when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
+    when(snapshotService.retrieveSnapshotSummary(snapshotId)).thenReturn(snapshotSummary);
+
+    // Mock storage and bucket for self-hosted dataset
+    Storage storage = mock(Storage.class);
+    Bucket bucket = mock(Bucket.class);
+    when(bucket.getLocation()).thenReturn("us-central1");
+    String datasetProject = snapshot.getSourceDataset().getProjectResource().getGoogleProjectId();
+    String sourcePath = googleFsFile.getCloudPath();
+    when(gcsProjectFactory.getStorage(datasetProject)).thenReturn(storage);
+    when(storage.get(eq(BlobId.fromGsUtilUri(sourcePath).getBucket()), any())).thenReturn(bucket);
+
+    // Create user with the test token
+    AuthenticatedUserRequest testUser =
+        AuthenticatedUserRequest.builder()
+            .setSubjectId("DatasetUnit")
+            .setEmail("dataset@unit.com")
+            .setToken(token)
+            .build();
+
+    // Mock SAM service for valid token case
+    if (!shouldThrow) {
+      when(samService.signUrlForBlob(testUser, "myProject", sourcePath, URL_TTL))
+          .thenReturn(
+              "https://storage.googleapis.com/path/to/file.txt"
+                  + "?requestedBy=%s&userProject=%s"
+                      .formatted(
+                          URLEncoder.encode(testUser.getEmail(), StandardCharsets.UTF_8),
+                          "myProject"));
+    }
+
+    DRSObject object = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    String accessId = object.getAccessMethods().get(0).getAccessId();
+
+    if (shouldThrow) {
+      assertThrows(
+          InvalidAuthorizationMethod.class,
+          () ->
+              drsService.getAccessUrlForObjectId(
+                  testUser, googleDrsObjectId, accessId, "myProject"));
+    } else {
+      // Should succeed with valid token
+      DRSAccessURL url =
+          drsService.getAccessUrlForObjectId(testUser, googleDrsObjectId, accessId, "myProject");
+      assertThat("returns url", url.getUrl(), containsString("storage.googleapis.com"));
+    }
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-473

https://github.com/DataBiosphere/terra-drs-hub/pull/247 and https://github.com/DataBiosphere/jade-data-repo/pull/2105 work together to support the (DRS resolution + passport + user-specified project for requester-pays) use case.

At a high level, these two PRs:
* In DRSHub, switch from using the GA4GH-standard DRS client library to the Terra-specific TDR client library for the TDR endpoint request in this specific use case. This allows passing the user's `Authorization: Bearer` token in the request.
* In TDR, add business logic to extract the bearer token from the request. We need this business logic because the TDR `/ga4gh/...` endpoint in question is missing some request headers that are only set by the oidc-proxy for requests under the `/api/...` prefix.

---

In this PR:
1. **Token validation**: Check for null/empty bearer token before calling SAM to sign URLs
   - Throws `InvalidAuthorizationMethod` when token is missing for self-hosted datasets with userProject
2. **BearerTokenFactory**: Use `BearerTokenFactory` instead of `ProxiedAuthenticatedUserRequestFactory` to extract the bearer token from the request. Supply dummy  "n/a" values for the user's email and subjectid when translating the `BearerTokenFactory` to a `AuthenticatedUserRequest`.   
