### PR TITLE
[CTM-499] update netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,15 @@ allprojects {
             dependency 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
         }
     }
+    // CVE-2026-42587: force all io.netty 4.1.x artifacts to patched version
+    configurations.all {
+        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'io.netty' && details.requested.version ==~ /4\.1\..*/) {
+                details.useVersion '4.1.133.Final'
+                details.because 'CVE-2026-42587'
+            }
+        }
+    }
 }
 
 apply from: 'debug.gradle'


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-499

## Addresses
Addresses [CVE-2026-42587](https://nvd.nist.gov/vuln/detail/CVE-2026-42587).

## Summary of changes
Force-upgrades all io.netty 4.1.x transitive dependencies to 4.1.133.Final via a resolutionStrategy.eachDependency block in allprojects. This approach is used instead of pinning individual artifacts because netty is pulled in transitively by multiple dependencies (Azure, Arrow, gRPC) across many modules, and a single rule handles all of them uniformly.  

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
