### PR TITLE
[CTM-534] check for requester pays

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -668,9 +668,9 @@ public class DrsService {
 
     final URL signedUrl;
     if (cachedSnapshot.isSelfHosted) {
-      // If a userProject is explicitly passed in, then use that to sign the url.
-      // Note: the expectation is that this is a Terra hosted bucket
-      if (!StringUtils.isEmpty(userProject)) {
+      // If a userProject is explicitly passed in and the snapshot requires it, use it to sign the
+      // url. Note: the expectation is that this is a Terra hosted bucket
+      if (!StringUtils.isEmpty(userProject) && cachedSnapshot.requireUserProject) {
         if (authUser != null && StringUtils.isNotBlank(authUser.getToken())) {
           logger.info(
               "Signing URL via SAM for snapshot {} with userProject '{}'",
@@ -726,10 +726,10 @@ public class DrsService {
       SnapshotCacheResult cachedSnapshot, String userProject, AuthenticatedUserRequest authUser) {
     final String signingProject;
     final String signingUser;
-    // If a user specifies a billing project in the request, prefer that over the snapshot's
-    // project.  If a billing project is required to access the data, and it is not provided,
-    // nothing will fail until the user tries to access the signed URL.
-    if (!StringUtils.isEmpty(userProject)) {
+    // Only use the caller's billing project if the snapshot requires requester pays.
+    // Ignoring a provided userProject for non-RP snapshots prevents incorrectly charging callers
+    // for data that is not intended to be requester-pays (e.g. HCA, LungMAP).
+    if (!StringUtils.isEmpty(userProject) && cachedSnapshot.requireUserProject) {
       signingProject = userProject;
     } else {
       signingProject = cachedSnapshot.googleProjectId;

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -828,6 +829,10 @@ class DrsServiceTest {
     Snapshot snapshot =
         mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
     snapshot.getSourceDataset().getDatasetSummary().selfHosted(selfHostedDataset);
+    // When a billing project is supplied, requireUserProject must be true for it to be honored
+    if (billingProject != null) {
+      snapshot.requireUserProject(true);
+    }
 
     Storage storage = mock(Storage.class);
     Bucket bucket = mock(Bucket.class);
@@ -924,6 +929,7 @@ class DrsServiceTest {
     Snapshot snapshot =
         mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
     snapshot.getSourceDataset().getDatasetSummary().selfHosted(true);
+    snapshot.requireUserProject(true);
     when(snapshotService.retrieve(snapshotId)).thenReturn(snapshot);
     when(snapshotService.retrieveSnapshotSummary(snapshotId)).thenReturn(snapshotSummary);
 
@@ -1081,6 +1087,29 @@ class DrsServiceTest {
         drsService.getAccessUrlForObjectId(
             TEST_USER, googleDrsObjectId, drsObject.getAccessMethods().get(0).getAccessId(), null);
     assertThat("returns a URL", result.getUrl(), containsString("storage.googleapis.com"));
+  }
+
+  @Test
+  void getAccessUrlIgnoresUserProjectForNonRequesterPaysSnapshot() throws Exception {
+    // Non-RP snapshot with userProject provided → should succeed without billing the caller
+    DRSObject drsObject = drsService.lookupObjectByDrsId(TEST_USER, googleDrsObjectId, false);
+    when(snapshotService.retrieveSnapshotSummary(snapshotId))
+        .thenReturn(new SnapshotSummaryModel().id(snapshotId));
+
+    Storage storage = mock(Storage.class);
+    when(drsService.initStorage(SNAPSHOT_DATA_PROJECT)).thenReturn(storage);
+    when(storage.signUrl(any(), any(long.class), any(), any(), any()))
+        .thenAnswer(a -> new java.net.URL("https://storage.googleapis.com/path/to/file.txt"));
+
+    DRSAccessURL result =
+        drsService.getAccessUrlForObjectId(
+            TEST_USER,
+            googleDrsObjectId,
+            drsObject.getAccessMethods().get(0).getAccessId(),
+            "caller-project");
+    assertThat("returns a URL", result.getUrl(), containsString("storage.googleapis.com"));
+    // SAM should not be called — the caller's project must not be used for billing
+    verify(samService, never()).signUrlForBlob(any(), any(), any(), any());
   }
 
   @Test


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-534

## Addresses
 TDR was using the `x-user-project header` as the billing project on any signed URL request, regardless of whether the snapshot had `requireUserProject=true`. Since Terra clients always send this header, all TDR-hosted data (HCA, LungMAP, etc.) was being charged to users — not just AnVIL requester-pays snapshots.  This pr gates `userProject` usage in `getUrlSigningOptions` and `signGoogleUrl` on `cachedSnapshot.requireUserProject`, so TDR only bills the caller when the snapshot explicitly requires it.

## Summary of changes
 `DrsService.java`                                                                                                                                                      
  - getUrlSigningOptions: only uses caller's userProject as billing project when cachedSnapshot.requireUserProject is true                                             
  - signGoogleUrl self-hosted branch: same gate — only routes through SAM with userProject when requireUserProject is true                                             
 
`DrsServiceTest.java `                                                                                                                                                 
  - testSignGcpUrl: added snapshot.requireUserProject(true) for the parameterized cases where a billing project is provided — those cases now explicitly test the RP scenario                                                                                                                                                             
  - testSignGcpUrlWithTokenVariations: added snapshot.requireUserProject(true) to correctly represent a self-hosted AnVIL snapshot                                     
  - New test getAccessUrlIgnoresUserProjectForNonRequesterPaysSnapshot: verifies the regression — non-RP snapshot with userProject provided succeeds but doesn't call SAM with the caller's project   

## Testing Strategy

<!-- Reminder -->
<!-- Two CODEOWNERS will be automatically assigned to review this pull request. If you otherwise have two reviewers, you do not need to wait for their review. -->
