### PR TITLE
CTM-553 - Make bearer token optional in postAccessURL endpoint

### DIFF
--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -9,6 +9,7 @@ import bio.terra.common.exception.NotImplementedException;
 import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
+import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.controller.DataRepositoryServiceApi;
 import bio.terra.model.DRSAccessURL;
@@ -182,11 +183,11 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
      header. For other cases (e.g. non-self-hosted snapshots), the token is not needed and we
      defer any auth enforcement to the service layer.
     */
+    BearerToken bearerToken = null;
     try {
-      var bearerToken = bearerTokenFactory.from(request);
+      bearerToken = bearerTokenFactory.from(request);
     } catch (Exception e) {
-      logger.error("Error occurred while retrieving bearer token", e);
-      var bearerToken = null;
+      logger.info("Bearer token was not provided or there was an error retrieving the token", e);
     }
 
     DRSAccessURL accessURL =

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -177,8 +177,13 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
        empty, the ProxiedAuthenticatedUserRequestFactory class will fail to create an
        AuthenticatedUserRequest object. Therefore, we must create a BearerToken instead of using
        getAuthenticatedInfo() to create an AuthenticatedUserRequest like other endpoints do.
+
+     The bearer token is only required for self-hosted snapshots accessed with an x-user-project
+     header. For other cases (e.g. non-self-hosted snapshots), the token is not needed and we
+     defer any auth enforcement to the service layer.
     */
-    var bearerToken = bearerTokenFactory.from(request);
+    var authorizationHeader = request.getHeader("Authorization");
+    var bearerToken = authorizationHeader != null ? bearerTokenFactory.from(request) : null;
 
     DRSAccessURL accessURL =
         drsService.postAccessUrlForObjectId(

--- a/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
+++ b/src/main/java/bio/terra/app/controller/DataRepositoryServiceApiController.java
@@ -182,8 +182,12 @@ public class DataRepositoryServiceApiController implements DataRepositoryService
      header. For other cases (e.g. non-self-hosted snapshots), the token is not needed and we
      defer any auth enforcement to the service layer.
     */
-    var authorizationHeader = request.getHeader("Authorization");
-    var bearerToken = authorizationHeader != null ? bearerTokenFactory.from(request) : null;
+    try {
+      var bearerToken = bearerTokenFactory.from(request);
+    } catch (Exception e) {
+      logger.error("Error occurred while retrieving bearer token", e);
+      var bearerToken = null;
+    }
 
     DRSAccessURL accessURL =
         drsService.postAccessUrlForObjectId(

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import bio.terra.app.configuration.ApplicationConfiguration;
 import bio.terra.common.TestUtils;
 import bio.terra.common.category.Unit;
+import bio.terra.common.exception.UnauthorizedException;
 import bio.terra.common.fixtures.AuthenticationFixtures;
 import bio.terra.common.iam.AuthenticatedUserRequest;
 import bio.terra.common.iam.AuthenticatedUserRequestFactory;
@@ -28,6 +29,7 @@ import bio.terra.service.filedata.exception.DrsObjectNotFoundException;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -76,7 +78,15 @@ class DataRepositoryServiceApiControllerTest {
   @BeforeEach
   void setUp() {
     when(authenticatedUserRequestFactory.from(any())).thenReturn(TEST_USER);
-    when(bearerTokenFactory.from(any())).thenReturn(TEST_TOKEN);
+    when(bearerTokenFactory.from(any()))
+        .thenAnswer(
+            invocation -> {
+              HttpServletRequest servletRequest = invocation.getArgument(0);
+              if (servletRequest.getHeader("Authorization") == null) {
+                throw new UnauthorizedException("Authorization header missing");
+              }
+              return TEST_TOKEN;
+            });
   }
 
   @Test

--- a/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
+++ b/src/test/java/bio/terra/app/controller/DataRepositoryServiceApiControllerTest.java
@@ -116,7 +116,7 @@ class DataRepositoryServiceApiControllerTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(TestUtils.mapToJson(PASSPORT)));
 
-    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(null, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenThrow(DrsObjectNotFoundException.class);
     mvc.perform(
             post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
@@ -135,7 +135,7 @@ class DataRepositoryServiceApiControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(DRS_ID));
 
-    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(null, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
     mvc.perform(
             post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
@@ -218,8 +218,7 @@ class DataRepositoryServiceApiControllerTest {
   @Test
   void testPostAccessURLLogsUserProject() throws Exception {
     String userProject = "my-gcp-project";
-    when(drsService.postAccessUrlForObjectId(
-            TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+    when(drsService.postAccessUrlForObjectId(null, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =
@@ -255,7 +254,7 @@ class DataRepositoryServiceApiControllerTest {
 
   @Test
   void testPostAccessURLLogsNullUserProject() throws Exception {
-    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+    when(drsService.postAccessUrlForObjectId(null, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
         .thenReturn(DRS_ACCESS_URL_OBJECT);
 
     Logger controllerLogger =
@@ -287,8 +286,7 @@ class DataRepositoryServiceApiControllerTest {
   @Test
   void testPostAccessURLRequiresBearerTokenWithUserProject() throws Exception {
     String userProject = "my-gcp-project";
-    when(drsService.postAccessUrlForObjectId(
-            TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
+    when(drsService.postAccessUrlForObjectId(null, DRS_ID, DRS_ACCESS_ID, PASSPORT, userProject))
         .thenThrow(
             new InvalidAuthorizationMethod(
                 "Bearer token required when using userProject with passport auth"));
@@ -299,6 +297,33 @@ class DataRepositoryServiceApiControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(TestUtils.mapToJson(PASSPORT)))
         .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void testPostAccessURLPassesNullTokenWhenNoAuthHeader() throws Exception {
+    when(drsService.postAccessUrlForObjectId(null, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+        .thenReturn(DRS_ACCESS_URL_OBJECT);
+
+    mvc.perform(
+            post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(PASSPORT)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.url").value(DRS_ACCESS_URL));
+  }
+
+  @Test
+  void testPostAccessURLPassesTokenWhenAuthHeaderPresent() throws Exception {
+    when(drsService.postAccessUrlForObjectId(TEST_TOKEN, DRS_ID, DRS_ACCESS_ID, PASSPORT, null))
+        .thenReturn(DRS_ACCESS_URL_OBJECT);
+
+    mvc.perform(
+            post(GET_DRS_OBJECT_ACCESS_ENDPOINT, DRS_ID, DRS_ACCESS_ID)
+                .header("Authorization", "Bearer " + TEST_USER.getToken())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(TestUtils.mapToJson(PASSPORT)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.url").value(DRS_ACCESS_URL));
   }
 
   @Test


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-553

## Summary

- `postAccessURL` (`POST /ga4gh/drs/v1/objects/{object_id}/access/{access_id}`) previously called `bearerTokenFactory.from(request)` unconditionally, throwing `UnauthorizedException` if no `Authorization` header was present.
- The bearer token is only actually used in `DrsService.signGoogleUrl` when two conditions are both true: the snapshot is **self-hosted** AND an `x-user-project` header is provided. In all other cases (non-self-hosted snapshots, or self-hosted with no user project) the token is never accessed.
- This change defers token enforcement to the service layer, which already handles a null token gracefully.


## Test plan

- [ ] Existing unit tests updated to expect `null` token when no `Authorization` header is sent
- [ ] `testPostAccessURLPassesNullTokenWhenNoAuthHeader` — verifies requests without an `Authorization` header succeed (token passed as `null` to service)
- [ ] `testPostAccessURLPassesTokenWhenAuthHeaderPresent` — verifies the token is still extracted and forwarded when the header is present
- [ ] All `DataRepositoryServiceApiControllerTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)