### PR TITLE
CTM-546: bump spring boot, which bumps netty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,22 @@ buildscript {
         // Required for gradle liquibase plugin
         classpath ('org.liquibase:liquibase-core:4.33.0')
     }
+    // Pin Jackson libs in the buildScript to 2.19.4 to support Jib. This is only for the buildScript.
+    // Note that Jackson used at runtime and compile time is 2.21.4 as of this writing, as specified
+    // by Spring Boot.
+    // jackson-annotations 2.20+ changed JsonProperty.isRequired() to return
+    // OptBoolean instead of boolean, which breaks jib with a NoSuchMethodError at :jib task execution.
+    configurations.classpath {
+        resolutionStrategy {
+            force 'com.fasterxml.jackson.core:jackson-annotations:2.19.4'
+            force 'com.fasterxml.jackson.core:jackson-databind:2.19.4'
+            force 'com.fasterxml.jackson.core:jackson-core:2.19.4'
+            force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.4'
+        }
+    }
 }
 
 plugins {
-    // This is set back to 3.4.2 because of: https://github.com/GoogleContainerTools/jib/issues/4265
     id 'com.google.cloud.tools.jib' version '3.5.3'
     id 'org.liquibase.gradle' version '3.1.0'
     id 'org.gradle.test-retry' version '1.6.4'

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ plugins {
     id 'org.gradle.test-retry' version '1.6.4'
     id 'antlr'
     id 'org.hidetake.swagger.generator' version '2.19.2'
-    id 'org.springframework.boot' version '3.5.12'
+    id 'org.springframework.boot' version '3.5.16'
     id 'idea'
     id 'java'
     id 'io.spring.dependency-management' version '1.1.7'
@@ -67,15 +67,6 @@ allprojects {
             dependency 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.77'
             dependency 'org.thymeleaf:thymeleaf:3.1.5.RELEASE'
             dependency 'org.thymeleaf:thymeleaf-spring6:3.1.5.RELEASE'
-        }
-    }
-    // CVE-2026-42587: force all io.netty 4.1.x artifacts to patched version
-    configurations.all {
-        resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-            if (details.requested.group == 'io.netty' && details.requested.version ==~ /4\.1\..*/) {
-                details.useVersion '4.1.133.Final'
-                details.because 'CVE-2026-42587'
-            }
         }
     }
     // CVE-2026-33117: force azure-security-keyvault-keys to patched version


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-546

Bump Spring Boot to latest 3.5.x version.

This bumps netty to `4.1.135.Final`, which is what the ticket CTM-546 requests.

```
❯ gw dependencyInsight --configuration runtimeClasspath --dependency io.netty:netty-handler

> Task :dependencyInsight
io.netty:netty-handler:4.1.135.Final
  Variant runtime:
    | Attribute Name                 | Provided     | Requested    |
    |--------------------------------|--------------|--------------|
    | org.gradle.status              | release      |              |
    | org.gradle.category            | library      | library      |
    | org.gradle.libraryelements     | jar          | jar          |
    | org.gradle.usage               | java-runtime | java-runtime |
    | org.gradle.dependency.bundling |              | external     |
    | org.gradle.jvm.environment     |              | standard-jvm |
    | org.gradle.jvm.version         |              | 17           |
   Selection reasons:
      - Selected by rule
      - By constraint

io.netty:netty-handler:4.1.135.Final
+--- io.netty:netty-codec-http:4.1.135.Final

```