### PR TITLE
CTM-615: Don't build AuthenticatedUserRequest with a null token

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -507,14 +507,18 @@ public class DrsService {
        The BearerToken comes from the /ga4gh/drs/v1/objects/{object_id}/access/{access_id} endpoint,
        which only has an access token and does not have the user's email or subjectid.
        Because AuthenticatedUserRequest requires email/subjectid, we have to supply dummy
-       values.
+       values. AuthenticatedUserRequest.Builder.build() rejects a null/empty token, so skip
+       building one entirely when there's no bearer token (e.g. passport-only callers) -- the
+       GCS signing path tolerates a null authUser.
     */
     AuthenticatedUserRequest authUserOnlyForUserProjectAccess =
-        AuthenticatedUserRequest.builder()
-            .setToken(bearerToken != null ? bearerToken.getToken() : null)
-            .setEmail("n/a")
-            .setSubjectId("n/a")
-            .build();
+        bearerToken == null
+            ? null
+            : AuthenticatedUserRequest.builder()
+                .setToken(bearerToken.getToken())
+                .setEmail("n/a")
+                .setSubjectId("n/a")
+                .build();
     return getAccessURL(authUserOnlyForUserProjectAccess, drsObject, accessId, userProject);
   }
 
@@ -638,7 +642,7 @@ public class DrsService {
                 new BlobSasTokenOptions(
                     URL_TTL,
                     new BlobSasPermission().setReadPermission(true),
-                    authUser.getEmail())));
+                    authUser != null ? authUser.getEmail() : null)));
   }
 
   private DRSAccessURL signGoogleUrl(

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -754,6 +754,44 @@ class DrsServiceTest {
   }
 
   @Test
+  void postAccessUrlForObjectIdNullTokenNoUserProject() throws MalformedURLException {
+    // Passport-only callers (no Authorization header, e.g. external RAS access) send a null
+    // BearerToken. The signing path should tolerate a null authUser and still return a signed
+    // URL, so long as no x-user-project is required.
+    when(snapshotService.retrieveSnapshotSummary(snapshotId))
+        .thenReturn(
+            new SnapshotSummaryModel().id(snapshotId).phsId("phs100789").consentCode("c99"));
+    when(snapshotService.verifyPassportAuth(any(), any()))
+        .thenReturn(new ValidatePassportResult().putAuditInfoItem("test", "log").valid(true));
+    Snapshot snapshot =
+        mockSnapshot(snapshotId, billingProfile.getId(), CloudPlatform.GCP, SNAPSHOT_DATA_PROJECT);
+    String snapshotProject = snapshot.getProjectResource().getGoogleProjectId();
+    Storage storage = mock(Storage.class);
+    when(gcsProjectFactory.getStorage(snapshot.getProjectResource().getGoogleProjectId()))
+        .thenReturn(storage);
+    String sourcePath = googleFsFile.getCloudPath();
+    String expectedUrl = "https://storage.googleapis.com/path/to/file.txt";
+    when(storage.signUrl(
+            eq(BlobInfo.newBuilder(GcsUriUtils.parseBlobUri(sourcePath)).build()),
+            eq(60L),
+            eq(TimeUnit.MINUTES),
+            any(),
+            any()))
+        .thenReturn(new URL(expectedUrl));
+    when(drsService.initStorage(snapshotProject)).thenReturn(storage);
+
+    DRSAccessURL url =
+        drsService.postAccessUrlForObjectId(
+            null,
+            googleDrsObjectId,
+            "gcp-passport-us-central1*" + snapshotId,
+            drsPassportRequestModel,
+            null);
+
+    assertThat("returns url", url.getUrl(), containsString(expectedUrl));
+  }
+
+  @Test
   void postAccessUrlForObjectIdInvalidPassport() {
     when(snapshotService.retrieveSnapshotSummary(snapshotId))
         .thenReturn(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-615

## Summary
- `DrsService.postAccessUrlForObjectId` was still calling `AuthenticatedUserRequest.builder().build()` even when the bearer token was `null`, and the builder rejects a null/empty token with `IllegalStateException("Token is empty")`. This 500'd passport-only callers (no `Authorization` header) one layer past the 401 fixed in CTM-553/#2113, since the GCS signing path (`signGoogleUrl`/`getUrlSigningOptions`) already tolerates a null `authUser`.
- Skip building the `AuthenticatedUserRequest` entirely when there's no bearer token; pass `authUser = null` straight through instead.
- Companion fix: `signAzureUrl` null-guards the `authUser.getEmail()` lookup so a null `authUser` doesn't trade the "Token is empty" 500 for an `NPE` 500 on the Azure branch. (This mirrors the GCP fix; verified downstream in `KeySasUrlFactory` that a null `contentDisposition` is already handled with `StringUtils.isNotBlank(...)`, so it's safe.)

## Test plan
- [x] Added `DrsServiceTest.postAccessUrlForObjectIdNullTokenNoUserProject`: passport-only, null bearer token, no `userProject` → expects a signed URL (was 500ing before the fix).
- [x] Existing `DrsServiceTest` and `DataRepositoryServiceApiControllerTest` suites pass.
- [ ] No dedicated Azure-backed-snapshot test was added for the companion fix — it prevents the NPE but end-to-end Azure signing for a passport-only caller isn't exercised here (that flow was called out of scope in the underlying report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)