### PR TITLE
CTM-612 - Allow passport auth for public NRES snapshots without a phsId

### DIFF
--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -196,12 +196,13 @@ public class DrsService {
       List<SnapshotSummaryModel> snapshotSummaries =
           snapshots.stream().map(SnapshotCacheResult::id).map(this::getSnapshotSummary).toList();
 
-      return buildDRSAuth(
+      boolean passportAuthorizationAvailable =
           snapshotSummaries.stream()
               .anyMatch(
                   summary ->
                       SnapshotSummary.passportAuthorizationAvailable(summary)
-                          || snapshotService.canBypassPassportValidation(summary)));
+                          || snapshotService.canBypassPassportValidation(summary));
+      return buildDRSAuth(passportAuthorizationAvailable);
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -197,7 +197,11 @@ public class DrsService {
           snapshots.stream().map(SnapshotCacheResult::id).map(this::getSnapshotSummary).toList();
 
       return buildDRSAuth(
-          snapshotSummaries.stream().anyMatch(SnapshotSummary::passportAuthorizationAvailable));
+          snapshotSummaries.stream()
+              .anyMatch(
+                  summary ->
+                      SnapshotSummary.passportAuthorizationAvailable(summary)
+                          || snapshotService.canBypassPassportValidation(summary)));
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -196,9 +196,8 @@ public class DrsService {
       List<SnapshotSummaryModel> snapshotSummaries =
           snapshots.stream().map(SnapshotCacheResult::id).map(this::getSnapshotSummary).toList();
 
-      boolean passportAuthorizationAvailable =
-          snapshotSummaries.stream().anyMatch(SnapshotSummary::passportAuthorizationAvailable);
-      return buildDRSAuth(passportAuthorizationAvailable);
+      return buildDRSAuth(
+          snapshotSummaries.stream().anyMatch(SnapshotSummary::passportAuthorizationAvailable));
     }
   }
 

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -197,8 +197,7 @@ public class DrsService {
           snapshots.stream().map(SnapshotCacheResult::id).map(this::getSnapshotSummary).toList();
 
       boolean passportAuthorizationAvailable =
-          snapshotSummaries.stream()
-              .anyMatch(summary -> SnapshotSummary.passportAuthorizationAvailable(summary));
+          snapshotSummaries.stream().anyMatch(SnapshotSummary::passportAuthorizationAvailable);
       return buildDRSAuth(passportAuthorizationAvailable);
     }
   }

--- a/src/main/java/bio/terra/service/filedata/DrsService.java
+++ b/src/main/java/bio/terra/service/filedata/DrsService.java
@@ -198,10 +198,7 @@ public class DrsService {
 
       boolean passportAuthorizationAvailable =
           snapshotSummaries.stream()
-              .anyMatch(
-                  summary ->
-                      SnapshotSummary.passportAuthorizationAvailable(summary)
-                          || snapshotService.canBypassPassportValidation(summary));
+              .anyMatch(summary -> SnapshotSummary.passportAuthorizationAvailable(summary));
       return buildDRSAuth(passportAuthorizationAvailable);
     }
   }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -232,11 +232,11 @@ public class SnapshotSummary {
   /**
    * @param model a SnapshotSummaryModel
    * @return whether the snapshot has a public consent code (NRES) that allows bypass of passport
-   *     validation when the snapshot is also publicly accessible
+   *     validation when the snapshot is also publicly accessible. PhsId is not required, since NRES
+   *     snapshots don't need a RAS visa to be validated against.
    */
   public static boolean isPublicConsentCode(SnapshotSummaryModel model) {
-    return !StringUtils.isBlank(model.getPhsId())
-        && !StringUtils.isBlank(model.getConsentCode())
+    return !StringUtils.isBlank(model.getConsentCode())
         && NRES_CONSENT_CODE.equalsIgnoreCase(model.getConsentCode());
   }
 }

--- a/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotSummary.java
@@ -226,7 +226,10 @@ public class SnapshotSummary {
    * @return whether the underlying snapshot can be accessed via RAS passport authorization
    */
   public static boolean passportAuthorizationAvailable(SnapshotSummaryModel model) {
-    return !StringUtils.isBlank(model.getPhsId()) && !StringUtils.isBlank(model.getConsentCode());
+    var passportAvailable =
+        !StringUtils.isBlank(model.getPhsId()) && !StringUtils.isBlank(model.getConsentCode());
+    var publicConsentCode = isPublicConsentCode(model);
+    return passportAvailable || publicConsentCode;
   }
 
   /**

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -648,14 +648,13 @@ class DrsServiceTest {
     SnapshotSummaryModel snapshotSummary =
         new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
     when(snapshotService.retrieveSnapshotSummary(snapshotId)).thenReturn(snapshotSummary);
-    when(snapshotService.canBypassPassportValidation(snapshotSummary)).thenReturn(true);
 
     assertThat(
-        "Passport authorization not directly available without PHS ID",
-        !SnapshotSummary.passportAuthorizationAvailable(snapshotSummary));
+        "Passport authorization is available for NRES snapshots without a PHS ID",
+        SnapshotSummary.passportAuthorizationAvailable(snapshotSummary));
     DRSAuthorizations auths = drsService.lookupAuthorizationsByDrsId(googleDrsObjectId);
     assertThat(
-        "PassportAuth is still supported via public NRES bypass",
+        "PassportAuth is supported via NRES bypass",
         auths.getSupportedTypes(),
         contains(
             DRSAuthorizations.SupportedTypesEnum.PASSPORTAUTH,

--- a/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
+++ b/src/test/java/bio/terra/service/filedata/DrsServiceTest.java
@@ -644,6 +644,25 @@ class DrsServiceTest {
   }
 
   @Test
+  void lookupAuthorizationsByDrsIdWithPublicNRESWithoutPHS() {
+    SnapshotSummaryModel snapshotSummary =
+        new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
+    when(snapshotService.retrieveSnapshotSummary(snapshotId)).thenReturn(snapshotSummary);
+    when(snapshotService.canBypassPassportValidation(snapshotSummary)).thenReturn(true);
+
+    assertThat(
+        "Passport authorization not directly available without PHS ID",
+        !SnapshotSummary.passportAuthorizationAvailable(snapshotSummary));
+    DRSAuthorizations auths = drsService.lookupAuthorizationsByDrsId(googleDrsObjectId);
+    assertThat(
+        "PassportAuth is still supported via public NRES bypass",
+        auths.getSupportedTypes(),
+        contains(
+            DRSAuthorizations.SupportedTypesEnum.PASSPORTAUTH,
+            DRSAuthorizations.SupportedTypesEnum.BEARERAUTH));
+  }
+
+  @Test
   void lookupAuthorizationsByDrsIdWithPassportIdentifiers() {
     SnapshotSummaryModel snapshotSummary =
         new SnapshotSummaryModel().id(snapshotId).phsId("phs100789").consentCode("c99");

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -672,37 +672,13 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void canBypassPassportValidationWithoutPhsIdWhenPublic() {
+  void canBypassPassportValidationWithoutPhsId() {
     SnapshotSummaryModel nresWithoutPhsId =
         new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
 
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(true);
-
     assertThat(
-        "Public NRES snapshot can bypass validation even without phsId",
+        "NRES snapshot can bypass validation even without phsId",
         service.canBypassPassportValidation(nresWithoutPhsId));
-    verify(iamService, times(1))
-        .getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name()));
-  }
-
-  @Test
-  void canBypassPassportValidationWithoutPhsIdWhenPrivate() {
-    SnapshotSummaryModel nresWithoutPhsId =
-        new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(false);
-
-    assertThat(
-        "Private NRES snapshot without phsId still cannot bypass validation",
-        !service.canBypassPassportValidation(nresWithoutPhsId));
-    verify(iamService, times(1))
-        .getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name()));
   }
 
   @Test
@@ -729,56 +705,15 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void verifyPassportAuthBypassForPublicNRESWithoutPhsId() {
+  void verifyPassportAuthBypassForNRESWithoutPhsId() {
     SnapshotSummaryModel nresSnapshot =
         new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(true);
 
     ValidatePassportResult result =
         service.verifyPassportAuth(nresSnapshot, List.of("fake-passport"));
 
     assertThat("Validation result is valid", result.isValid(), is(true));
     // Verify that ECM was NOT called for passport validation
-    verifyNoInteractions(ecmService);
-  }
-
-  @Test
-  void verifyPassportAuthRequiresValidationForPrivateNRES() {
-    SnapshotSummaryModel nresSnapshot =
-        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(false); // Not public
-
-    ValidatePassportResult mockResult = new ValidatePassportResult().valid(true);
-    when(ecmService.validatePassport(any())).thenReturn(mockResult);
-
-    ValidatePassportResult result =
-        service.verifyPassportAuth(nresSnapshot, List.of("valid-passport"));
-
-    assertThat("Validation result is valid", result.isValid(), is(true));
-    // Verify that ECM WAS called for validation
-    verify(ecmService, times(1)).validatePassport(any());
-  }
-
-  @Test
-  void verifyPassportAuthBypassNotAvailableWithoutToken() {
-    SnapshotSummaryModel nresSnapshot =
-        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(true);
-
-    ValidatePassportResult result =
-        service.verifyPassportAuth(nresSnapshot, List.of("fake-passport"));
-
-    assertThat("Validation result is valid", result.isValid(), is(true));
-    // Verify that ECM was NOT called - bypass should work even without separate user token
     verifyNoInteractions(ecmService);
   }
 

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -637,10 +637,11 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void isPublicConsentCodeRequiresPhsId() {
+  void isPublicConsentCodeDoesNotRequirePhsId() {
     SnapshotSummaryModel nresWithoutPhsId = new SnapshotSummaryModel().consentCode("NRES");
     assertThat(
-        "NRES without phsId is not public", !SnapshotSummary.isPublicConsentCode(nresWithoutPhsId));
+        "NRES without phsId is still public",
+        SnapshotSummary.isPublicConsentCode(nresWithoutPhsId));
   }
 
   @Test
@@ -671,12 +672,37 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void canBypassPassportValidationWithoutPhsId() {
+  void canBypassPassportValidationWithoutPhsIdWhenPublic() {
     SnapshotSummaryModel nresWithoutPhsId =
         new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
 
+    when(iamService.getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
+        .thenReturn(true);
+
     assertThat(
-        "Cannot bypass without phsId", !service.canBypassPassportValidation(nresWithoutPhsId));
+        "Public NRES snapshot can bypass validation even without phsId",
+        service.canBypassPassportValidation(nresWithoutPhsId));
+    verify(iamService, times(1))
+        .getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name()));
+  }
+
+  @Test
+  void canBypassPassportValidationWithoutPhsIdWhenPrivate() {
+    SnapshotSummaryModel nresWithoutPhsId =
+        new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
+
+    when(iamService.getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
+        .thenReturn(false);
+
+    assertThat(
+        "Private NRES snapshot without phsId still cannot bypass validation",
+        !service.canBypassPassportValidation(nresWithoutPhsId));
+    verify(iamService, times(1))
+        .getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name()));
   }
 
   @Test
@@ -699,6 +725,60 @@ class SnapshotServiceTest {
 
     assertThat("Validation result is valid", result.isValid(), is(true));
     // Verify that ECM was NOT called for passport validation
+    verifyNoInteractions(ecmService);
+  }
+
+  @Test
+  void verifyPassportAuthBypassForPublicNRESWithoutPhsId() {
+    SnapshotSummaryModel nresSnapshot =
+        new SnapshotSummaryModel().id(snapshotId).consentCode("NRES");
+
+    when(iamService.getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
+        .thenReturn(true);
+
+    ValidatePassportResult result =
+        service.verifyPassportAuth(nresSnapshot, List.of("fake-passport"));
+
+    assertThat("Validation result is valid", result.isValid(), is(true));
+    // Verify that ECM was NOT called for passport validation
+    verifyNoInteractions(ecmService);
+  }
+
+  @Test
+  void verifyPassportAuthRequiresValidationForPrivateNRES() {
+    SnapshotSummaryModel nresSnapshot =
+        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
+
+    when(iamService.getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
+        .thenReturn(false); // Not public
+
+    ValidatePassportResult mockResult = new ValidatePassportResult().valid(true);
+    when(ecmService.validatePassport(any())).thenReturn(mockResult);
+
+    ValidatePassportResult result =
+        service.verifyPassportAuth(nresSnapshot, List.of("valid-passport"));
+
+    assertThat("Validation result is valid", result.isValid(), is(true));
+    // Verify that ECM WAS called for validation
+    verify(ecmService, times(1)).validatePassport(any());
+  }
+
+  @Test
+  void verifyPassportAuthBypassNotAvailableWithoutToken() {
+    SnapshotSummaryModel nresSnapshot =
+        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
+
+    when(iamService.getPolicyPublicV2AsSA(
+            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
+        .thenReturn(true);
+
+    ValidatePassportResult result =
+        service.verifyPassportAuth(nresSnapshot, List.of("fake-passport"));
+
+    assertThat("Validation result is valid", result.isValid(), is(true));
+    // Verify that ECM was NOT called - bypass should work even without separate user token
     verifyNoInteractions(ecmService);
   }
 


### PR DESCRIPTION
## Summary
- Normally passport auth requires both phsId and consentCode to be set. This adds an exception: when consentCode is NRES (non-restricted) and the snapshot is public, passport auth is now allowed even if phsId is blank, since the bypass path never needs to build a RAS visa criterion in that case.
- SnapshotSummary.isPublicConsentCode no longer requires phsId, only a non-blank consentCode equal to NRES (case-insensitive).
- DrsService.lookupAuthorizationsByDrsId now also advertises PASSPORTAUTH support when SnapshotService.canBypassPassportValidation is true, so phsId-less public NRES snapshots correctly advertise passport auth as supported.

## Test plan
Will test when deployed

## Ticket
https://github.com/DataBiosphere/jade-data-repo/pull/2124