### PR TITLE
CTM-612 - Remove public-policy check from passport validation bypass

### DIFF
--- a/src/main/java/bio/terra/service/auth/iam/IamService.java
+++ b/src/main/java/bio/terra/service/auth/iam/IamService.java
@@ -633,12 +633,6 @@ public class IamService {
         () -> iamProvider.getPolicyPublicV2(token, iamResourceType, resourceId, policyName));
   }
 
-  public boolean getPolicyPublicV2AsSA(
-      IamResourceType iamResourceType, UUID resourceId, String policyName) {
-    String tdrSaAccessToken = googleCredentialsService.getApplicationDefaultAccessToken(SCOPES);
-    return getPolicyPublicV2(tdrSaAccessToken, iamResourceType, resourceId, policyName);
-  }
-
   public void setPolicyPublicV2(
       String token,
       IamResourceType iamResourceType,

--- a/src/main/java/bio/terra/service/snapshot/SnapshotService.java
+++ b/src/main/java/bio/terra/service/snapshot/SnapshotService.java
@@ -858,39 +858,13 @@ public class SnapshotService {
   }
 
   /**
-   * Check if a snapshot is publicly accessible with NRES consent code, allowing passport validation
-   * to be bypassed. This is specifically for determining if passport validation can be skipped for
-   * public NRES snapshots.
+   * Check if a snapshot has an NRES consent code, allowing passport validation to be bypassed.
    *
    * @param summary the snapshot summary model including the snapshot ID
-   * @return true if snapshot has NRES consent code AND public reader policy
+   * @return true if snapshot has NRES consent code
    */
   public boolean canBypassPassportValidation(SnapshotSummaryModel summary) {
-    // First check: Must have NRES consent code
-    if (!SnapshotSummary.isPublicConsentCode(summary)) {
-      return false;
-    }
-
-    // Second check: Snapshot must be public
-    return isSnapshotPublic(summary.getId());
-  }
-
-  /*
-   * Check if snapshot is marked as public in SAM
-   * Perform check as the TDR Service Account
-   */
-  @VisibleForTesting
-  boolean isSnapshotPublic(UUID snapshotId) {
-    try {
-      return iamService.getPolicyPublicV2AsSA(
-          IamResourceType.DATASNAPSHOT, snapshotId, IamRole.READER.name());
-    } catch (Exception e) {
-      logger.warn(
-          "Error checking public status for snapshot {}, cannot bypass passport validation",
-          snapshotId,
-          e);
-      return false;
-    }
+    return SnapshotSummary.isPublicConsentCode(summary);
   }
 
   /**

--- a/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
+++ b/src/test/java/bio/terra/service/snapshot/SnapshotServiceTest.java
@@ -652,37 +652,12 @@ class SnapshotServiceTest {
   }
 
   @Test
-  void canBypassPassportValidationForPublicNRES() {
+  void canBypassPassportValidationForNRES() {
     SnapshotSummaryModel nresSnapshot =
         new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
 
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(true);
-
     assertThat(
-        "Public NRES snapshot can bypass validation",
-        service.canBypassPassportValidation(nresSnapshot));
-    verify(iamService, times(1))
-        .getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name()));
-  }
-
-  @Test
-  void canBypassPassportValidationForPrivateNRES() {
-    SnapshotSummaryModel nresSnapshot =
-        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(false);
-
-    assertThat(
-        "Private NRES snapshot cannot bypass validation",
-        !service.canBypassPassportValidation(nresSnapshot));
-    verify(iamService, times(1))
-        .getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name()));
+        "NRES snapshot can bypass validation", service.canBypassPassportValidation(nresSnapshot));
   }
 
   @Test
@@ -693,7 +668,6 @@ class SnapshotServiceTest {
     assertThat(
         "Non-NRES snapshot cannot bypass validation",
         !service.canBypassPassportValidation(nonNresSnapshot));
-    verify(iamService, never()).getPolicyPublicV2AsSA(any(), any(), anyString());
   }
 
   @Test
@@ -703,7 +677,6 @@ class SnapshotServiceTest {
 
     assertThat(
         "Cannot bypass without phsId", !service.canBypassPassportValidation(nresWithoutPhsId));
-    verify(iamService, never()).getPolicyPublicV2AsSA(any(), any(), anyString());
   }
 
   @Test
@@ -714,60 +687,18 @@ class SnapshotServiceTest {
     assertThat(
         "Cannot bypass without consent code",
         !service.canBypassPassportValidation(phsIdWithoutConsent));
-    verify(iamService, never()).getPolicyPublicV2AsSA(any(), any(), anyString());
   }
 
   @Test
-  void verifyPassportAuthBypassForPublicNRES() {
+  void verifyPassportAuthBypassForNRES() {
     SnapshotSummaryModel nresSnapshot =
         new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(true);
 
     ValidatePassportResult result =
         service.verifyPassportAuth(nresSnapshot, List.of("fake-passport"));
 
     assertThat("Validation result is valid", result.isValid(), is(true));
     // Verify that ECM was NOT called for passport validation
-    verifyNoInteractions(ecmService);
-  }
-
-  @Test
-  void verifyPassportAuthRequiresValidationForPrivateNRES() {
-    SnapshotSummaryModel nresSnapshot =
-        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(false); // Not public
-
-    ValidatePassportResult mockResult = new ValidatePassportResult().valid(true);
-    when(ecmService.validatePassport(any())).thenReturn(mockResult);
-
-    ValidatePassportResult result =
-        service.verifyPassportAuth(nresSnapshot, List.of("valid-passport"));
-
-    assertThat("Validation result is valid", result.isValid(), is(true));
-    // Verify that ECM WAS called for validation
-    verify(ecmService, times(1)).validatePassport(any());
-  }
-
-  @Test
-  void verifyPassportAuthBypassNotAvailableWithoutToken() {
-    SnapshotSummaryModel nresSnapshot =
-        new SnapshotSummaryModel().id(snapshotId).phsId(PHS_ID).consentCode("NRES");
-
-    when(iamService.getPolicyPublicV2AsSA(
-            eq(IamResourceType.DATASNAPSHOT), eq(snapshotId), eq(IamRole.READER.name())))
-        .thenReturn(true);
-
-    ValidatePassportResult result =
-        service.verifyPassportAuth(nresSnapshot, List.of("fake-passport"));
-
-    assertThat("Validation result is valid", result.isValid(), is(true));
-    // Verify that ECM was NOT called - bypass should work even without separate user token
     verifyNoInteractions(ecmService);
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-612

## Summary
The `IamService.getPolicyPublicV2AsSA` check was broken because the TDR service account does not have read_policy:: reader access on the snapshot and cannot successfully check whether the snapshot is policy. After considering a [few alternatives](https://docs.google.com/document/d/1OwNYSZ9w3s6PG9v_miXAlsJX3q18KnRAbb5kETITB_I/edit?tab=t.0#heading=h.xd8dcja3em9w), we have decided to remove the check that the snapshot is public and rely on the `NRES` consent code. 

## The changes
- `canBypassPassportValidation` now bypasses passport validation based solely on the NRES consent code, dropping the redundant SAM public-reader-policy check.
- Removed the now-unused `SnapshotService.isSnapshotPublic` and `IamService.getPolicyPublicV2AsSA` helpers.
- Updated/removed associated unit tests in `SnapshotServiceTest` to match the simplified behavior.

## Test plan
Will test after deployed
