### PR TITLE
CTM-661: add db indexes for retrieveSnapshot()

### DIFF
--- a/src/main/resources/db/changelog.xml
+++ b/src/main/resources/db/changelog.xml
@@ -94,4 +94,5 @@
     <include file="changesets/20250218_dataset_inherit_steward_flag.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20251008_add_indexes_getaccessiblesnapshots.yaml" relativeToChangelogFile="true"/>
     <include file="changesets/20260310_snapshot_require_user_project.yaml" relativeToChangelogFile="true"/>
+    <include file="changesets/20260903_snapshot_metadata_fk_indexes.yaml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changesets/20260903_snapshot_metadata_fk_indexes.yaml
+++ b/src/main/resources/db/changesets/20260903_snapshot_metadata_fk_indexes.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: snapshot_metadata_fk_indexes
+      author: davidan
+      remarks: |
+        Add indexes for the foreign keys that SnapshotDao.retrieveSnapshot
+        uses for GET /api/repository/v1/snapshots/{id}.
+      changes:
+        - createIndex:
+            indexName: snapshot_table_parent_id_idx
+            tableName: snapshot_table
+            columns:
+              - column:
+                  name: parent_id
+        - createIndex:
+            indexName: snapshot_column_table_id_idx
+            tableName: snapshot_column
+            columns:
+              - column:
+                  name: table_id
+        - createIndex:
+            indexName: snapshot_map_table_source_id_idx
+            tableName: snapshot_map_table
+            columns:
+              - column:
+                  name: source_id
+        - createIndex:
+            indexName: snapshot_map_column_map_table_id_idx
+            tableName: snapshot_map_column
+            columns:
+              - column:
+                  name: map_table_id


### PR DESCRIPTION
__Jira ticket__: https://broadworkbench.atlassian.net/browse/CTM-661

## Addresses

TDR's Postgres instance saw its CPU pegged at 100% for ~2 hours. This has happened multiple times in the past week.
<img width="3072" height="698" alt="Screenshot 03-09-2026 at 15 36" src="https://github.com/user-attachments/assets/b86b6537-05f7-4df5-b327-8277b2371a91" />

## Summary of changes

This PR adds indexes to four columns used by `GET /api/repository/v1/snapshots/{id}`, to retrieve a single snapshot. 

## Details

The most recent CPU spike was triggered by a surge in traffic from `azul-ucsc-0-hammerbox@platform-anvil-prod.iam.gserviceaccount.com`.
<img width="3184" height="894" alt="Screenshot 03-09-2026 at 15 59" src="https://github.com/user-attachments/assets/929584fc-cfa4-479e-8a50-1171b1a74a93" />

Claude quantified this traffic as:
> 50,911 executions of the per-snapshot queries, over only 275 distinct snapshot IDs (~185× re-fetch each)
> steady ~390 req/min, starting 20:20, stopping dead at 22:33

This increased traffic to `GET /api/repository/v1/snapshots/{id}` in turn caused the db to struggle because the SQL powering this API is inefficient. Two separate queries - `SnapshotTableDao.sqlSelectTable` and `SnapshotMapTablesDao.retrieveMapTables` - each perform _*full table scans*_ on two columns each. The size of the tables in question is not large, but under this kind of load they struggled mightily.

Running `explain` against the two queries proves this out - look for the two `""Node Type"": ""Seq Scan""` callouts in each of these:

<details>
<summary>SnapshotTableDao.sqlSelectTable</summary>

```diff
"QUERY PLAN"
"[
  {
    ""Plan"": {
      ""Node Type"": ""Sort"",
      ""Parallel Aware"": false,
      ""Async Capable"": false,
      ""Startup Cost"": 1542.01,
      ""Total Cost"": 1542.12,
      ""Plan Rows"": 43,
      ""Plan Width"": 124,
      ""Actual Startup Time"": 14.640,
      ""Actual Total Time"": 14.665,
      ""Actual Rows"": 171,
      ""Actual Loops"": 1,
      ""Output"": [""t.id"", ""t.name"", ""t.row_count"", ""t.primary_key"", ""c.id"", ""c.name"", ""c.type"", ""c.array_of"", ""c.required"", ""t.ctid"", ""c.ordinal""],
      ""Sort Key"": [""t.ctid"", ""c.ordinal""],
      ""Sort Method"": ""quicksort"",
      ""Sort Space Used"": 48,
      ""Sort Space Type"": ""Memory"",
      ""Shared Hit Blocks"": 873,
      ""Shared Read Blocks"": 0,
      ""Shared Dirtied Blocks"": 0,
      ""Shared Written Blocks"": 0,
      ""Local Hit Blocks"": 0,
      ""Local Read Blocks"": 0,
      ""Local Dirtied Blocks"": 0,
      ""Local Written Blocks"": 0,
      ""Temp Read Blocks"": 0,
      ""Temp Written Blocks"": 0,
      ""I/O Read Time"": 0.000,
      ""I/O Write Time"": 0.000,
      ""Temp I/O Read Time"": 0.000,
      ""Temp I/O Write Time"": 0.000,
      ""Plans"": [
        {
          ""Node Type"": ""Hash Join"",
          ""Parent Relationship"": ""Outer"",
          ""Parallel Aware"": false,
          ""Async Capable"": false,
          ""Join Type"": ""Inner"",
          ""Startup Cost"": 215.10,
          ""Total Cost"": 1540.85,
          ""Plan Rows"": 43,
          ""Plan Width"": 124,
          ""Actual Startup Time"": 2.067,
          ""Actual Total Time"": 14.418,
          ""Actual Rows"": 171,
          ""Actual Loops"": 1,
          ""Output"": [""t.id"", ""t.name"", ""t.row_count"", ""t.primary_key"", ""c.id"", ""c.name"", ""c.type"", ""c.array_of"", ""c.required"", ""t.ctid"", ""c.ordinal""],
          ""Inner Unique"": true,
          ""Hash Cond"": ""(c.table_id = t.id)"",
          ""Shared Hit Blocks"": 865,
          ""Shared Read Blocks"": 0,
          ""Shared Dirtied Blocks"": 0,
          ""Shared Written Blocks"": 0,
          ""Local Hit Blocks"": 0,
          ""Local Read Blocks"": 0,
          ""Local Dirtied Blocks"": 0,
          ""Local Written Blocks"": 0,
          ""Temp Read Blocks"": 0,
          ""Temp Written Blocks"": 0,
          ""I/O Read Time"": 0.000,
          ""I/O Write Time"": 0.000,
          ""Temp I/O Read Time"": 0.000,
          ""Temp I/O Write Time"": 0.000,
          ""Plans"": [
            {
-              ""Node Type"": ""Seq Scan"",
              ""Parent Relationship"": ""Outer"",
              ""Parallel Aware"": false,
              ""Async Capable"": false,
              ""Relation Name"": ""snapshot_column"",
              ""Schema"": ""public"",
              ""Alias"": ""c"",
              ""Startup Cost"": 0.00,
              ""Total Cost"": 1199.72,
              ""Plan Rows"": 47972,
              ""Plan Width"": 61,
              ""Actual Startup Time"": 0.009,
              ""Actual Total Time"": 9.593,
              ""Actual Rows"": 49377,
              ""Actual Loops"": 1,
              ""Output"": [""c.id"", ""c.name"", ""c.type"", ""c.array_of"", ""c.required"", ""c.ordinal"", ""c.table_id""],
              ""Shared Hit Blocks"": 720,
              ""Shared Read Blocks"": 0,
              ""Shared Dirtied Blocks"": 0,
              ""Shared Written Blocks"": 0,
              ""Local Hit Blocks"": 0,
              ""Local Read Blocks"": 0,
              ""Local Dirtied Blocks"": 0,
              ""Local Written Blocks"": 0,
              ""Temp Read Blocks"": 0,
              ""Temp Written Blocks"": 0,
              ""I/O Read Time"": 0.000,
              ""I/O Write Time"": 0.000,
              ""Temp I/O Read Time"": 0.000,
              ""Temp I/O Write Time"": 0.000
            },
            {
              ""Node Type"": ""Hash"",
              ""Parent Relationship"": ""Inner"",
              ""Parallel Aware"": false,
              ""Async Capable"": false,
              ""Startup Cost"": 215.04,
              ""Total Cost"": 215.04,
              ""Plan Rows"": 5,
              ""Plan Width"": 79,
              ""Actual Startup Time"": 0.753,
              ""Actual Total Time"": 0.755,
              ""Actual Rows"": 18,
              ""Actual Loops"": 1,
              ""Output"": [""t.id"", ""t.name"", ""t.row_count"", ""t.primary_key"", ""t.ctid""],
              ""Hash Buckets"": 1024,
              ""Original Hash Buckets"": 1024,
              ""Hash Batches"": 1,
              ""Original Hash Batches"": 1,
              ""Peak Memory Usage"": 10,
              ""Shared Hit Blocks"": 145,
              ""Shared Read Blocks"": 0,
              ""Shared Dirtied Blocks"": 0,
              ""Shared Written Blocks"": 0,
              ""Local Hit Blocks"": 0,
              ""Local Read Blocks"": 0,
              ""Local Dirtied Blocks"": 0,
              ""Local Written Blocks"": 0,
              ""Temp Read Blocks"": 0,
              ""Temp Written Blocks"": 0,
              ""I/O Read Time"": 0.000,
              ""I/O Write Time"": 0.000,
              ""Temp I/O Read Time"": 0.000,
              ""Temp I/O Write Time"": 0.000,
              ""Plans"": [
                {
-                  ""Node Type"": ""Seq Scan"",
                  ""Parent Relationship"": ""Outer"",
                  ""Parallel Aware"": false,
                  ""Async Capable"": false,
                  ""Relation Name"": ""snapshot_table"",
                  ""Schema"": ""public"",
                  ""Alias"": ""t"",
                  ""Startup Cost"": 0.00,
                  ""Total Cost"": 215.04,
                  ""Plan Rows"": 5,
                  ""Plan Width"": 79,
                  ""Actual Startup Time"": 0.138,
                  ""Actual Total Time"": 0.739,
                  ""Actual Rows"": 18,
                  ""Actual Loops"": 1,
                  ""Output"": [""t.id"", ""t.name"", ""t.row_count"", ""t.primary_key"", ""t.ctid""],
                  ""Filter"": ""(t.parent_id = 'e40bea8e-be23-441d-9a8b-a35abb213d2c'::uuid)"",
                  ""Rows Removed by Filter"": 5610,
                  ""Shared Hit Blocks"": 145,
                  ""Shared Read Blocks"": 0,
                  ""Shared Dirtied Blocks"": 0,
                  ""Shared Written Blocks"": 0,
                  ""Local Hit Blocks"": 0,
                  ""Local Read Blocks"": 0,
                  ""Local Dirtied Blocks"": 0,
                  ""Local Written Blocks"": 0,
                  ""Temp Read Blocks"": 0,
                  ""Temp Written Blocks"": 0,
                  ""I/O Read Time"": 0.000,
                  ""I/O Write Time"": 0.000,
                  ""Temp I/O Read Time"": 0.000,
                  ""Temp I/O Write Time"": 0.000
                }
              ]
            }
          ]
        }
      ]
    },
    ""Query Identifier"": -5805976077017921812,
    ""Planning"": {
      ""Shared Hit Blocks"": 302,
      ""Shared Read Blocks"": 0,
      ""Shared Dirtied Blocks"": 0,
      ""Shared Written Blocks"": 0,
      ""Local Hit Blocks"": 0,
      ""Local Read Blocks"": 0,
      ""Local Dirtied Blocks"": 0,
      ""Local Written Blocks"": 0,
      ""Temp Read Blocks"": 0,
      ""Temp Written Blocks"": 0,
      ""I/O Read Time"": 0.000,
      ""I/O Write Time"": 0.000,
      ""Temp I/O Read Time"": 0.000,
      ""Temp I/O Write Time"": 0.000
    },
    ""Planning Time"": 1.357,
    ""Triggers"": [
    ],
    ""Execution Time"": 14.919
  }
]"
```
</details>

<details>
<summary>SnapshotMapTablesDao.retrieveMapTables</summary>

```diff
"QUERY PLAN"
"[
  {
    ""Plan"": {
      ""Node Type"": ""Hash Join"",
      ""Parallel Aware"": false,
      ""Async Capable"": false,
      ""Join Type"": ""Inner"",
      ""Startup Cost"": 176.81,
      ""Total Cost"": 1457.32,
      ""Plan Rows"": 43,
      ""Plan Width"": 96,
      ""Actual Startup Time"": 2.166,
      ""Actual Total Time"": 14.619,
      ""Actual Rows"": 171,
      ""Actual Loops"": 1,
      ""Output"": [""smt.id"", ""smt.from_table_id"", ""smt.to_table_id"", ""smc.id"", ""smc.from_column_id"", ""smc.to_column_id""],
      ""Inner Unique"": true,
      ""Hash Cond"": ""(smc.map_table_id = smt.id)"",
      ""Shared Hit Blocks"": 778,
      ""Shared Read Blocks"": 0,
      ""Shared Dirtied Blocks"": 0,
      ""Shared Written Blocks"": 0,
      ""Local Hit Blocks"": 0,
      ""Local Read Blocks"": 0,
      ""Local Dirtied Blocks"": 0,
      ""Local Written Blocks"": 0,
      ""Temp Read Blocks"": 0,
      ""Temp Written Blocks"": 0,
      ""I/O Read Time"": 0.000,
      ""I/O Write Time"": 0.000,
      ""Temp I/O Read Time"": 0.000,
      ""Temp I/O Write Time"": 0.000,
      ""Plans"": [
        {
-          ""Node Type"": ""Seq Scan"",
          ""Parent Relationship"": ""Outer"",
          ""Parallel Aware"": false,
          ""Async Capable"": false,
          ""Relation Name"": ""snapshot_map_column"",
          ""Schema"": ""public"",
          ""Alias"": ""smc"",
          ""Startup Cost"": 0.00,
          ""Total Cost"": 1153.70,
          ""Plan Rows"": 48270,
          ""Plan Width"": 64,
          ""Actual Startup Time"": 0.009,
          ""Actual Total Time"": 5.756,
          ""Actual Rows"": 49341,
          ""Actual Loops"": 1,
          ""Output"": [""smc.id"", ""smc.map_table_id"", ""smc.from_column_id"", ""smc.to_column_id""],
          ""Shared Hit Blocks"": 671,
          ""Shared Read Blocks"": 0,
          ""Shared Dirtied Blocks"": 0,
          ""Shared Written Blocks"": 0,
          ""Local Hit Blocks"": 0,
          ""Local Read Blocks"": 0,
          ""Local Dirtied Blocks"": 0,
          ""Local Written Blocks"": 0,
          ""Temp Read Blocks"": 0,
          ""Temp Written Blocks"": 0,
          ""I/O Read Time"": 0.000,
          ""I/O Write Time"": 0.000,
          ""Temp I/O Read Time"": 0.000,
          ""Temp I/O Write Time"": 0.000
        },
        {
          ""Node Type"": ""Hash"",
          ""Parent Relationship"": ""Inner"",
          ""Parallel Aware"": false,
          ""Async Capable"": false,
          ""Startup Cost"": 176.75,
          ""Total Cost"": 176.75,
          ""Plan Rows"": 5,
          ""Plan Width"": 48,
          ""Actual Startup Time"": 0.589,
          ""Actual Total Time"": 0.590,
          ""Actual Rows"": 18,
          ""Actual Loops"": 1,
          ""Output"": [""smt.id"", ""smt.from_table_id"", ""smt.to_table_id""],
          ""Hash Buckets"": 1024,
          ""Original Hash Buckets"": 1024,
          ""Hash Batches"": 1,
          ""Original Hash Batches"": 1,
          ""Peak Memory Usage"": 10,
          ""Shared Hit Blocks"": 107,
          ""Shared Read Blocks"": 0,
          ""Shared Dirtied Blocks"": 0,
          ""Shared Written Blocks"": 0,
          ""Local Hit Blocks"": 0,
          ""Local Read Blocks"": 0,
          ""Local Dirtied Blocks"": 0,
          ""Local Written Blocks"": 0,
          ""Temp Read Blocks"": 0,
          ""Temp Written Blocks"": 0,
          ""I/O Read Time"": 0.000,
          ""I/O Write Time"": 0.000,
          ""Temp I/O Read Time"": 0.000,
          ""Temp I/O Write Time"": 0.000,
          ""Plans"": [
            {
-              ""Node Type"": ""Seq Scan"",
              ""Parent Relationship"": ""Outer"",
              ""Parallel Aware"": false,
              ""Async Capable"": false,
              ""Relation Name"": ""snapshot_map_table"",
              ""Schema"": ""public"",
              ""Alias"": ""smt"",
              ""Startup Cost"": 0.00,
              ""Total Cost"": 176.75,
              ""Plan Rows"": 5,
              ""Plan Width"": 48,
              ""Actual Startup Time"": 0.057,
              ""Actual Total Time"": 0.577,
              ""Actual Rows"": 18,
              ""Actual Loops"": 1,
              ""Output"": [""smt.id"", ""smt.from_table_id"", ""smt.to_table_id""],
              ""Filter"": ""(smt.source_id = 'ec740600-3e27-4613-bbe2-1c647bbdfe19'::uuid)"",
              ""Rows Removed by Filter"": 5604,
              ""Shared Hit Blocks"": 107,
              ""Shared Read Blocks"": 0,
              ""Shared Dirtied Blocks"": 0,
              ""Shared Written Blocks"": 0,
              ""Local Hit Blocks"": 0,
              ""Local Read Blocks"": 0,
              ""Local Dirtied Blocks"": 0,
              ""Local Written Blocks"": 0,
              ""Temp Read Blocks"": 0,
              ""Temp Written Blocks"": 0,
              ""I/O Read Time"": 0.000,
              ""I/O Write Time"": 0.000,
              ""Temp I/O Read Time"": 0.000,
              ""Temp I/O Write Time"": 0.000
            }
          ]
        }
      ]
    },
    ""Query Identifier"": 971855624158779861,
    ""Planning"": {
      ""Shared Hit Blocks"": 273,
      ""Shared Read Blocks"": 0,
      ""Shared Dirtied Blocks"": 0,
      ""Shared Written Blocks"": 0,
      ""Local Hit Blocks"": 0,
      ""Local Read Blocks"": 0,
      ""Local Dirtied Blocks"": 0,
      ""Local Written Blocks"": 0,
      ""Temp Read Blocks"": 0,
      ""Temp Written Blocks"": 0,
      ""I/O Read Time"": 0.000,
      ""I/O Write Time"": 0.000,
      ""Temp I/O Read Time"": 0.000,
      ""Temp I/O Write Time"": 0.000
    },
    ""Planning Time"": 1.889,
    ""Triggers"": [
    ],
    ""Execution Time"": 14.765
  }
]"
```
</details>

We should probably figure out why `azul-ucsc-0-hammerbox@platform-anvil-prod.iam.gserviceaccount.com` needs to call retrieveSnapshot this many times, including repeated queries to the same snapshot, but we should also fix our db.


